### PR TITLE
Stream Output object method declarations

### DIFF
--- a/src/Compiler/AST/ASTEnums.h
+++ b/src/Compiler/AST/ASTEnums.h
@@ -720,6 +720,9 @@ enum class Intrinsic
     Texture_SampleLevel_3,  // SampleLevel(SamplerState S, float[1,2,3,4] Location, float LOD)
     Texture_SampleLevel_4,  // SampleLevel(SamplerState S, float[1,2,3,4] Location, float LOD, int[1,2,3] Offset)
     Texture_SampleLevel_5,  // SampleLevel(SamplerState S, float[1,2,3,4] Location, float LOD, int[1,2,3] Offset, out uint Status)
+
+    StreamOutput_Append,
+    StreamOutput_RestartStrip,
 };
 
 // Container structure for all kinds of intrinsic call usages (can be used as std::map<Intrinsic, IntrinsicUsage>

--- a/src/Compiler/Frontend/HLSL/HLSLIntrinsics.cpp
+++ b/src/Compiler/Frontend/HLSL/HLSLIntrinsics.cpp
@@ -167,6 +167,9 @@ static HLSLIntrinsicsMap GenerateIntrinsicMap()
         { "SampleCmpLevelZero",                 { T::Texture_SampleCmp_3,               4, 0 } }, // Identical to SampleCmp (but only for Level 0)
         { "SampleGrad",                         { T::Texture_SampleGrad_4,              4, 0 } },
         { "SampleLevel",                        { T::Texture_SampleLevel_3,             4, 0 } },
+
+        { "Append",                             { T::StreamOutput_Append,               4, 0 } },
+        { "RestartStrip",                       { T::StreamOutput_RestartStrip,         4, 0 } },
     };
 }
 
@@ -442,6 +445,9 @@ static std::map<Intrinsic, IntrinsicDescriptor> GenerateIntrinsicDescriptorMap()
         { T::Texture_SampleLevel_3,             { DataType::Float4, 3 } },
         { T::Texture_SampleLevel_4,             { DataType::Float4, 4 } },
         { T::Texture_SampleLevel_5,             { DataType::Float4, 5 } },
+
+        { T::StreamOutput_Append,               { 1 }                   },
+        { T::StreamOutput_RestartStrip,         { }                     },
     };
 }
 


### PR DESCRIPTION
Added StreamOutput.Append & StreamOutput.RestartStrip declaration.
This will allow a shader containing a geometry shader to be parsed, and targets other than the geometry shader be converted successfully.
