### PR TITLE
'groupshared' qualified variables should be writeable

### DIFF
--- a/src/Compiler/AST/AST.cpp
+++ b/src/Compiler/AST/AST.cpp
@@ -1292,7 +1292,7 @@ void VarDeclStmnt::ForEachVarDecl(const VarDeclIteratorFunctor& iterator)
 void VarDeclStmnt::MakeImplicitConst()
 {
     if (!IsConstOrUniform() && typeSpecifier->storageClasses.find(StorageClass::Static) == typeSpecifier->storageClasses.end()
-		&& typeSpecifier->storageClasses.find(StorageClass::GroupShared) == typeSpecifier->storageClasses.end())
+        && typeSpecifier->storageClasses.find(StorageClass::GroupShared) == typeSpecifier->storageClasses.end())
     {
         flags << VarDeclStmnt::isImplicitConst;
         typeSpecifier->isUniform = true;

--- a/src/Compiler/AST/AST.cpp
+++ b/src/Compiler/AST/AST.cpp
@@ -1291,7 +1291,8 @@ void VarDeclStmnt::ForEachVarDecl(const VarDeclIteratorFunctor& iterator)
 
 void VarDeclStmnt::MakeImplicitConst()
 {
-    if (!IsConstOrUniform() && typeSpecifier->storageClasses.find(StorageClass::Static) == typeSpecifier->storageClasses.end())
+    if (!IsConstOrUniform() && typeSpecifier->storageClasses.find(StorageClass::Static) == typeSpecifier->storageClasses.end()
+		&& typeSpecifier->storageClasses.find(StorageClass::GroupShared) == typeSpecifier->storageClasses.end())
     {
         flags << VarDeclStmnt::isImplicitConst;
         typeSpecifier->isUniform = true;

--- a/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
@@ -63,11 +63,11 @@ void GLSLGenerator::GenerateCodePrimary(
     compactWrappers_    = outputDesc.formatting.compactWrappers;
     alwaysBracedScopes_ = outputDesc.formatting.alwaysBracedScopes;
 
-	for (const auto& s : outputDesc.vertexSemantics)
-	{
-		CiString semantic = ToCiString(s.semantic);
-		vertexSemanticsMap_[semantic] = { s.location, 0 };
-	}
+    for (const auto& s : outputDesc.vertexSemantics)
+    {
+        CiString semantic = ToCiString(s.semantic);
+        vertexSemanticsMap_[semantic] = { s.location, 0 };
+    }
 
     if (program.entryPointRef)
     {

--- a/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
@@ -63,8 +63,11 @@ void GLSLGenerator::GenerateCodePrimary(
     compactWrappers_    = outputDesc.formatting.compactWrappers;
     alwaysBracedScopes_ = outputDesc.formatting.alwaysBracedScopes;
 
-    for (const auto& s : outputDesc.vertexSemantics)
-        vertexSemanticsMap_[ToCiString(s.semantic)] = { s.location, 0 };
+	for (const auto& s : outputDesc.vertexSemantics)
+	{
+		CiString semantic = ToCiString(s.semantic);
+		vertexSemanticsMap_[semantic] = { s.location, 0 };
+	}
 
     if (program.entryPointRef)
     {


### PR DESCRIPTION
Hi.

So far 'groupshared' variables were being marked as implicitly constant. So when I try to translate this code:

```
groupshared uint sCount;

[numthreads(32, 32, 1)]
void main()
{
    sCount++;
}
```

It would fail with:

> context error (<unnamed>:6:5) : illegal assignment to l-value 'sCount' that is implicitly declared as constant

Yet they should be writable and therefore non-const.