### PR TITLE
Added support for Interlocked (atomic) intrinsics executed over image buffers

### DIFF
--- a/src/Compiler/AST/ASTEnums.h
+++ b/src/Compiler/AST/ASTEnums.h
@@ -752,6 +752,15 @@ enum class Intrinsic
 
     Image_Store,                // GLSL only
     Image_Load,                 // GLSL only
+
+    Image_AtomicAdd,            // GLSL only
+    Image_AtomicAnd,            // GLSL only
+    Image_AtomicOr,             // GLSL only
+    Image_AtomicXor,            // GLSL only
+    Image_AtomicMin,            // GLSL only
+    Image_AtomicMax,            // GLSL only
+    Image_AtomicCompSwap,       // GLSL only
+    Image_AtomicExchange        // GLSL only
 };
 
 // Container structure for all kinds of intrinsic call usages (can be used as std::map<Intrinsic, IntrinsicUsage>

--- a/src/Compiler/AST/Visitor/ExprConverter.cpp
+++ b/src/Compiler/AST/Visitor/ExprConverter.cpp
@@ -430,9 +430,33 @@ void ExprConverter::IfFlaggedConvertExprIfCastRequired(ExprPtr& expr, const Type
 #define IMPLEMENT_VISIT_PROC(AST_NAME) \
     void ExprConverter::Visit##AST_NAME(AST_NAME* ast, void* args)
 
+bool IsInterlockedIntristic(Intrinsic intrisic)
+{
+    switch(intrisic)
+    {
+    case Intrinsic::InterlockedAdd:
+    case Intrinsic::InterlockedAnd:
+    case Intrinsic::InterlockedOr:
+    case Intrinsic::InterlockedXor:
+    case Intrinsic::InterlockedMin:
+    case Intrinsic::InterlockedMax:
+    case Intrinsic::InterlockedCompareExchange:
+    case Intrinsic::InterlockedExchange:
+        return true;
+    default:
+        return false;
+    }
+}
+
 IMPLEMENT_VISIT_PROC(FunctionCall)
 {
-    ConvertExprList(ast->arguments, AllPreVisit);
+    Flags preVisitFlags = AllPreVisit;
+
+    /** Interlock (atomic) intristics require actual buffer, and not their contents. */
+    if (IsInterlockedIntristic(ast->intrinsic))
+        preVisitFlags = preVisitFlags & ~ConvertImageAccess;
+
+    ConvertExprList(ast->arguments, preVisitFlags);
     {
         VISIT_DEFAULT(FunctionCall);
     }

--- a/src/Compiler/Backend/GLSL/GLSLConverter.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.cpp
@@ -822,6 +822,16 @@ void GLSLConverter::ConvertIntrinsicCall(FunctionCall* ast)
         case Intrinsic::Texture_SampleLevel_5:
             ConvertIntrinsicCallTextureSampleLevel(ast);
             break;
+        case Intrinsic::InterlockedAdd:
+        case Intrinsic::InterlockedAnd:
+        case Intrinsic::InterlockedOr:
+        case Intrinsic::InterlockedXor:
+        case Intrinsic::InterlockedMin:
+        case Intrinsic::InterlockedMax:
+        case Intrinsic::InterlockedCompareExchange:
+        case Intrinsic::InterlockedExchange:
+            ConvertIntrinsicCallImageAtomic(ast);
+            break;
         default:
             break;
     }
@@ -911,6 +921,62 @@ void GLSLConverter::ConvertIntrinsicCallTextureSampleLevel(FunctionCall* ast)
         if (args.size() >= 4)
             exprConverter_.ConvertExprIfCastRequired(args[3], VectorDataType(DataType::Int, vectorSize), true);
     }
+}
+
+void GLSLConverter::ConvertIntrinsicCallImageAtomic(FunctionCall* ast)
+{
+    /* Convert "atomic*" to "imageAtomic*" for buffer types */
+    if (ast->arguments.size() == 2)
+    {
+        auto argTypeDen = ast->arguments.front()->GetTypeDenoter()->Get();
+        if (argTypeDen->IsBuffer())
+        {
+            if (auto varIdent = ast->arguments.front()->FetchVarIdent())
+            {
+                if (auto bufferDecl = varIdent->FetchSymbol<BufferDecl>())
+                {
+                    /* Is the buffer declaration a read/write texture? */
+                    const auto bufferType = bufferDecl->GetBufferType();
+                    if (IsRWTextureBufferType(bufferType))
+                    {
+                        switch (ast->intrinsic)
+                        {
+                        case Intrinsic::InterlockedAdd:
+                            ast->intrinsic = Intrinsic::Image_AtomicAdd;
+                            break;
+                        case Intrinsic::InterlockedAnd:
+                            ast->intrinsic = Intrinsic::Image_AtomicAnd;
+                            break;
+                        case Intrinsic::InterlockedOr:
+                            ast->intrinsic = Intrinsic::Image_AtomicOr;
+                            break;
+                        case Intrinsic::InterlockedXor:
+                            ast->intrinsic = Intrinsic::Image_AtomicXor;
+                            break;
+                        case Intrinsic::InterlockedMin:
+                            ast->intrinsic = Intrinsic::Image_AtomicMin;
+                            break;
+                        case Intrinsic::InterlockedMax:
+                            ast->intrinsic = Intrinsic::Image_AtomicMax;
+                            break;
+                        case Intrinsic::InterlockedCompareExchange:
+                            ast->intrinsic = Intrinsic::Image_AtomicCompSwap;
+                            break;
+                        case Intrinsic::InterlockedExchange:
+                            ast->intrinsic = Intrinsic::Image_AtomicExchange;
+                            break;
+                        default:
+                            break;
+                        }
+                    }
+                }
+            }
+            else
+                RuntimeErr(R_InvalidIntrinsicArgType("atomic*"), ast);
+        }
+    }
+    else
+        RuntimeErr(R_InvalidIntrinsicArgCount("atomic*"), ast);
 }
 
 void GLSLConverter::ConvertFunctionCall(FunctionCall* ast)

--- a/src/Compiler/Backend/GLSL/GLSLConverter.h
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.h
@@ -149,6 +149,7 @@ class GLSLConverter : public Visitor
         void ConvertIntrinsicCallSaturate(FunctionCall* ast);
         void ConvertIntrinsicCallTextureSample(FunctionCall* ast);
         void ConvertIntrinsicCallTextureSampleLevel(FunctionCall* ast);
+        void ConvertIntrinsicCallImageAtomic(FunctionCall* ast);
 
         void ConvertFunctionCall(FunctionCall* ast);
 

--- a/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
@@ -305,6 +305,8 @@ IMPLEMENT_VISIT_PROC(FunctionCall)
         WriteFunctionCallIntrinsicClip(ast);
     else if (ast->intrinsic >= Intrinsic::InterlockedAdd && ast->intrinsic <= Intrinsic::InterlockedXor)
         WriteFunctionCallIntrinsicAtomic(ast);
+    else if (ast->intrinsic >= Intrinsic::Image_AtomicAdd && ast->intrinsic <= Intrinsic::Image_AtomicExchange)
+        WriteFunctionCallIntrinsicAtomic(ast);
     else if (ast->intrinsic == Intrinsic::StreamOutput_Append)
         WriteFunctionCallIntrinsicStreamOutputAppend(ast);
     else if (ast->intrinsic == Intrinsic::Texture_QueryLod)

--- a/src/Compiler/Backend/GLSL/GLSLIntrinsics.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLIntrinsics.cpp
@@ -194,8 +194,17 @@ static std::map<Intrinsic, std::string> GenerateIntrinsicMap()
         { T::StreamOutput_Append,              "EmitVertex"            },
         { T::StreamOutput_RestartStrip,        "EndPrimitive"          },
 
-        { T::Image_Load,                       "imageLoad"             },
-        { T::Image_Store,                      "imageStore"            },
+        { T::Image_Load,                       "imageLoad"             }, // GLSL only
+        { T::Image_Store,                      "imageStore"            }, // GLSL only
+
+        { T::Image_AtomicAdd,                  "imageAtomicAdd"        }, // GLSL only
+        { T::Image_AtomicAnd,                  "imageAtomicAnd"        }, // GLSL only
+        { T::Image_AtomicCompSwap,             "imageAtomicCompSwap"   }, // GLSL only
+        { T::Image_AtomicExchange,             "imageAtomicExchange"   }, // GLSL only
+        { T::Image_AtomicMax,                  "imageAtomicMax"        }, // GLSL only
+        { T::Image_AtomicMin,                  "imageAtomicMin"        }, // GLSL only
+        { T::Image_AtomicOr,                   "imageAtomicOr"         }, // GLSL only
+        { T::Image_AtomicXor,                  "imageAtomicXor"        }, // GLSL only
     };
 }
 

--- a/src/Compiler/Frontend/HLSL/HLSLIntrinsics.cpp
+++ b/src/Compiler/Frontend/HLSL/HLSLIntrinsics.cpp
@@ -517,6 +517,15 @@ static std::map<Intrinsic, IntrinsicSignature> GenerateIntrinsicSignatureMap()
 
         { T::Image_Load,                       { Ret::Float4,      2    } },
         { T::Image_Store,                      {                   3    } },
+
+        { T::Image_AtomicAdd,                  {                   2, 3 } },
+        { T::Image_AtomicAnd,                  {                   2, 3 } },
+        { T::Image_AtomicCompSwap,             {                   4    } },
+        { T::Image_AtomicExchange,             {                   3    } },
+        { T::Image_AtomicMax,                  {                   2, 3 } },
+        { T::Image_AtomicMin,                  {                   2, 3 } },
+        { T::Image_AtomicOr,                   {                   2, 3 } },
+        { T::Image_AtomicXor,                  {                   2, 3 } },
     };
 }
 


### PR DESCRIPTION
HLSL `Interlocked*` methods operate equally on shared variables and buffers, but GLSL has separate `atomic*` vs `imageAtomic*` intrinsics for each, respectively. This patch adds support for translation of such HLSL intrinsics to `imageAtomic*` when used on buffers.