### PR TITLE
Buffer, RWBuffer -> samplerBuffer, imageBuffer

### DIFF
--- a/src/Compiler/AST/ASTEnums.cpp
+++ b/src/Compiler/AST/ASTEnums.cpp
@@ -779,7 +779,8 @@ std::string BufferTypeToString(const BufferType t)
 
 bool IsStorageBufferType(const BufferType t)
 {
-    return (t >= BufferType::Buffer && t <= BufferType::ConsumeStructuredBuffer);
+    return (t >= BufferType::StructuredBuffer && t <= BufferType::ByteAddressBuffer) ||
+           (t >= BufferType::RWStructuredBuffer && t <= BufferType::ConsumeStructuredBuffer);
 }
 
 bool IsRWBufferType(const BufferType t)
@@ -789,13 +790,12 @@ bool IsRWBufferType(const BufferType t)
 
 bool IsRWTextureBufferType(const BufferType t)
 {
-    // TODO: RWBuffer should map to 'imageBuffer', but it currently maps to 'buffer' (SSBO), so we ignore it here for now
-    return (t >= BufferType::RWTexture1D && t <= BufferType::RWTexture3D);
+    return (t >= BufferType::RWTexture1D && t <= BufferType::RWTexture3D) || t == BufferType::RWBuffer;
 }
 
 bool IsTextureBufferType(const BufferType t)
 {
-    return (t >= BufferType::RWTexture1D && t <= BufferType::GenericTexture);
+    return (t >= BufferType::RWTexture1D && t <= BufferType::GenericTexture) || t == BufferType::Buffer;
 }
 
 bool IsTextureMSBufferType(const BufferType t)

--- a/src/Compiler/AST/ASTEnums.h
+++ b/src/Compiler/AST/ASTEnums.h
@@ -419,7 +419,7 @@ enum class BufferType
 
 std::string BufferTypeToString(const BufferType t);
 
-// Returns true if the specified buffer type is a storage buffer type (e.g. BufferType::Buffer, or BufferType::RWStructuredBuffer).
+// Returns true if the specified buffer type is a storage buffer type (i.e. gets converted to a 'buffer' block in GLSL).
 bool IsStorageBufferType(const BufferType t);
 
 // Returns true if the specified buffer type is a RW (read/write) buffer type.

--- a/src/Compiler/AST/ASTFactory.cpp
+++ b/src/Compiler/AST/ASTFactory.cpp
@@ -234,6 +234,19 @@ ArrayExprPtr MakeArrayExpr(const ExprPtr& prefixExpr, const std::vector<int>& ar
     return ast;
 }
 
+TypeDenoterPtr MakeBufferAccessCallTypeDenoter(const BaseTypeDenoter& bufferTypeDenoter)
+{
+    auto typeDenoter = std::make_shared<BaseTypeDenoter>();
+    if (IsIntType(bufferTypeDenoter.dataType))
+        typeDenoter->dataType = DataType::Int4;
+    else if (IsUIntType(bufferTypeDenoter.dataType))
+        typeDenoter->dataType = DataType::UInt4;
+    else
+        typeDenoter->dataType = DataType::Float4;
+    
+    return typeDenoter;
+}
+
 BracketExprPtr MakeBracketExpr(const ExprPtr& expr)
 {
     auto ast = MakeASTWithOrigin<BracketExpr>(expr);

--- a/src/Compiler/AST/ASTFactory.h
+++ b/src/Compiler/AST/ASTFactory.h
@@ -57,6 +57,8 @@ ObjectExprPtr                   MakeObjectExpr(Decl* symbolRef);
 
 ArrayExprPtr                    MakeArrayExpr(const ExprPtr& prefixExpr, const std::vector<int>& arrayIndices);
 
+TypeDenoterPtr                  MakeBufferAccessCallTypeDenoter(const BaseTypeDenoter& bufferTypeDenoter);
+
 // Makes a new bracket expression with the specified sub expression (source area is copied).
 BracketExprPtr                  MakeBracketExpr(const ExprPtr& expr);
 

--- a/src/Compiler/AST/Visitor/ExprConverter.cpp
+++ b/src/Compiler/AST/Visitor/ExprConverter.cpp
@@ -349,23 +349,28 @@ void ExprConverter::ConvertExprSamplerBufferAccessArray(ExprPtr& expr, ArrayExpr
             {
                 /* Get buffer type denoter from array indices of array access plus identifier */
                 auto bufferTypeDen = bufferDecl->GetTypeDenoter()->GetSub(arrayExpr);
+				if (auto baseBufferTypeDen = bufferTypeDen->As<BaseTypeDenoter>())
+				{
+					/* Create a call denoter for the return value */
+					auto callTypeDen = ASTFactory::MakeBufferAccessCallTypeDenoter(*baseBufferTypeDen);
 
-                if (!arrayExpr->arrayIndices.empty())
-                {
-                    /* Make first argument expression */
-                    auto arg0Expr = arrayExpr->prefixExpr;
-                    arg0Expr->flags << Expr::wasConverted;
+					if (!arrayExpr->arrayIndices.empty())
+					{
+						/* Make first argument expression */
+						auto arg0Expr = arrayExpr->prefixExpr;
+						arg0Expr->flags << Expr::wasConverted;
 
-                    /* Get second argument expression (last array index) */
-                    auto arg1Expr = arrayExpr->arrayIndices.back();
+						/* Get second argument expression (last array index) */
+						auto arg1Expr = arrayExpr->arrayIndices.back();
 
-                    /* Convert expression to intrinsic call */
-                    expr = ASTFactory::MakeIntrinsicCallExpr(
-                        Intrinsic::Texture_Load_1, "texelFetch", bufferTypeDen, { arg0Expr, arg1Expr }
-                    );
-                }
-                else
-                    RuntimeErr(R_MissingArrayIndexInOp(bufferTypeDen->ToString()), arrayExpr);
+						/* Convert expression to intrinsic call */
+						expr = ASTFactory::MakeIntrinsicCallExpr(
+							Intrinsic::Texture_Load_1, "texelFetch", callTypeDen, { arg0Expr, arg1Expr }
+						);
+					}
+					else
+						RuntimeErr(R_MissingArrayIndexInOp(bufferTypeDen->ToString()), arrayExpr);
+				}
             }
         }
     }

--- a/src/Compiler/AST/Visitor/ExprConverter.cpp
+++ b/src/Compiler/AST/Visitor/ExprConverter.cpp
@@ -252,6 +252,7 @@ void ExprConverter::ConvertExprImageAccessArray(ExprPtr& expr, ArrayExpr* arrayE
 {
     /* Fetch buffer type denoter from l-value prefix expression */
     const auto& prefixTypeDen = arrayExpr->prefixExpr->GetTypeDenoter()->GetAliased();
+
     if (auto bufferTypeDen = prefixTypeDen.As<BufferTypeDenoter>())
     {
         if (auto bufferDecl = bufferTypeDen->bufferDeclRef)
@@ -262,55 +263,60 @@ void ExprConverter::ConvertExprImageAccessArray(ExprPtr& expr, ArrayExpr* arrayE
             {
                 /* Get buffer type denoter from array indices of array access plus identifier */
                 auto bufferTypeDen = bufferDecl->GetTypeDenoter()->GetSub(arrayExpr);
-
-                if (!arrayExpr->arrayIndices.empty())
+                if (auto baseBufferTypeDen = bufferTypeDen->As<BaseTypeDenoter>())
                 {
-                    /* Make first argument expression */
-                    auto arg0Expr = arrayExpr->prefixExpr;
-                    arg0Expr->flags << Expr::wasConverted;
+                    /* Create a call denoter for the return value */
+                    auto callTypeDen = ASTFactory::MakeBufferAccessCallTypeDenoter(*baseBufferTypeDen);
 
-                    /* Get second argument expression (last array index) */
-                    auto arg1Expr = arrayExpr->arrayIndices.back();
-
-                    if (assignExpr)
+                    if (!arrayExpr->arrayIndices.empty())
                     {
-                        /* Get third argument expression (store value) */
-                        ExprPtr arg2Expr;
+                        /* Make first argument expression */
+                        auto arg0Expr = arrayExpr->prefixExpr;
+                        arg0Expr->flags << Expr::wasConverted;
 
-                        if (assignExpr->op == AssignOp::Set)
+                        /* Get second argument expression (last array index) */
+                        auto arg1Expr = arrayExpr->arrayIndices.back();
+
+                        if (assignExpr)
                         {
-                            /* Take r-value expression for standard assignemnt */
-                            arg2Expr = assignExpr->rvalueExpr;
-                        }
-                        else 
-                        {
-                            /* Make compound assignment with an image-load instruction first */
-                            auto lhsExpr = ASTFactory::MakeIntrinsicCallExpr(
-                                Intrinsic::Image_Load, "imageLoad", bufferTypeDen, { arg0Expr, arg1Expr }
+                            /* Get third argument expression (store value) */
+                            ExprPtr arg2Expr;
+
+                            if (assignExpr->op == AssignOp::Set)
+                            {
+                                /* Take r-value expression for standard assignemnt */
+                                arg2Expr = assignExpr->rvalueExpr;
+                            }
+                            else
+                            {
+                                /* Make compound assignment with an image-load instruction first */
+                                auto lhsExpr = ASTFactory::MakeIntrinsicCallExpr(
+                                    Intrinsic::Image_Load, "imageLoad", callTypeDen, { arg0Expr, arg1Expr }
+                                );
+
+                                auto rhsExpr = assignExpr->rvalueExpr;
+
+                                const auto binaryOp = AssignOpToBinaryOp(assignExpr->op);
+
+                                arg2Expr = ASTFactory::MakeBinaryExpr(lhsExpr, binaryOp, rhsExpr);
+                            }
+
+                            /* Convert expression to intrinsic call */
+                            expr = ASTFactory::MakeIntrinsicCallExpr(
+                                Intrinsic::Image_Store, "imageStore", nullptr, { arg0Expr, arg1Expr, arg2Expr }
                             );
-
-                            auto rhsExpr = assignExpr->rvalueExpr;
-
-                            const auto binaryOp = AssignOpToBinaryOp(assignExpr->op);
-
-                            arg2Expr = ASTFactory::MakeBinaryExpr(lhsExpr, binaryOp, rhsExpr);
                         }
-
-                        /* Convert expression to intrinsic call */
-                        expr = ASTFactory::MakeIntrinsicCallExpr(
-                            Intrinsic::Image_Store, "imageStore", nullptr, { arg0Expr, arg1Expr, arg2Expr }
-                        );
+                        else
+                        {
+                            /* Convert expression to intrinsic call */
+                            expr = ASTFactory::MakeIntrinsicCallExpr(
+                                Intrinsic::Image_Load, "imageLoad", callTypeDen, { arg0Expr, arg1Expr }
+                            );
+                        }
                     }
                     else
-                    {
-                        /* Convert expression to intrinsic call */
-                        expr = ASTFactory::MakeIntrinsicCallExpr(
-                            Intrinsic::Image_Load, "imageLoad", bufferTypeDen, { arg0Expr, arg1Expr }
-                        );
-                    }
+                        RuntimeErr(R_MissingArrayIndexInOp(bufferTypeDen->ToString()), arrayExpr);
                 }
-                else
-                    RuntimeErr(R_MissingArrayIndexInOp(bufferTypeDen->ToString()), arrayExpr);
             }
         }
     }

--- a/src/Compiler/AST/Visitor/ExprConverter.cpp
+++ b/src/Compiler/AST/Visitor/ExprConverter.cpp
@@ -349,28 +349,28 @@ void ExprConverter::ConvertExprSamplerBufferAccessArray(ExprPtr& expr, ArrayExpr
             {
                 /* Get buffer type denoter from array indices of array access plus identifier */
                 auto bufferTypeDen = bufferDecl->GetTypeDenoter()->GetSub(arrayExpr);
-				if (auto baseBufferTypeDen = bufferTypeDen->As<BaseTypeDenoter>())
-				{
-					/* Create a call denoter for the return value */
-					auto callTypeDen = ASTFactory::MakeBufferAccessCallTypeDenoter(*baseBufferTypeDen);
+                if (auto baseBufferTypeDen = bufferTypeDen->As<BaseTypeDenoter>())
+                {
+                    /* Create a call denoter for the return value */
+                    auto callTypeDen = ASTFactory::MakeBufferAccessCallTypeDenoter(*baseBufferTypeDen);
 
-					if (!arrayExpr->arrayIndices.empty())
-					{
-						/* Make first argument expression */
-						auto arg0Expr = arrayExpr->prefixExpr;
-						arg0Expr->flags << Expr::wasConverted;
+                    if (!arrayExpr->arrayIndices.empty())
+                    {
+                        /* Make first argument expression */
+                        auto arg0Expr = arrayExpr->prefixExpr;
+                        arg0Expr->flags << Expr::wasConverted;
 
-						/* Get second argument expression (last array index) */
-						auto arg1Expr = arrayExpr->arrayIndices.back();
+                        /* Get second argument expression (last array index) */
+                        auto arg1Expr = arrayExpr->arrayIndices.back();
 
-						/* Convert expression to intrinsic call */
-						expr = ASTFactory::MakeIntrinsicCallExpr(
-							Intrinsic::Texture_Load_1, "texelFetch", callTypeDen, { arg0Expr, arg1Expr }
-						);
-					}
-					else
-						RuntimeErr(R_MissingArrayIndexInOp(bufferTypeDen->ToString()), arrayExpr);
-				}
+                        /* Convert expression to intrinsic call */
+                        expr = ASTFactory::MakeIntrinsicCallExpr(
+                            Intrinsic::Texture_Load_1, "texelFetch", callTypeDen, { arg0Expr, arg1Expr }
+                        );
+                    }
+                    else
+                        RuntimeErr(R_MissingArrayIndexInOp(bufferTypeDen->ToString()), arrayExpr);
+                }
             }
         }
     }

--- a/src/Compiler/AST/Visitor/ExprConverter.h
+++ b/src/Compiler/AST/Visitor/ExprConverter.h
@@ -37,22 +37,23 @@ class ExprConverter : public Visitor
         // Conversion flags enumeration.
         enum : unsigned int
         {
-            ConvertVectorSubscripts = (1 << 0),
-            ConvertVectorCompare    = (1 << 1),
-            ConvertImageAccess      = (1 << 2),
-            ConvertImplicitCasts    = (1 << 3),
-            ConvertInitializer      = (1 << 4),
-            ConvertLog10            = (1 << 5), // Converts "log10(x)" to "(log(x) / log(10))"
-            ConvertUnaryExpr        = (1 << 6), // Wraps an unary expression if it's parent expression is also an unary expression (e.g. "-+x" to "-(+x)")
+            ConvertVectorSubscripts     = (1 << 0),
+            ConvertVectorCompare        = (1 << 1),
+            ConvertImageAccess          = (1 << 2),
+            ConvertImplicitCasts        = (1 << 3),
+            ConvertInitializer          = (1 << 4),
+            ConvertLog10                = (1 << 5), // Converts "log10(x)" to "(log(x) / log(10))"
+            ConvertUnaryExpr            = (1 << 6), // Wraps an unary expression if it's parent expression is also an unary expression (e.g. "-+x" to "-(+x)")
+            ConvertSamplerBufferAccess  = (1 << 7),
 
             // All conversion flags commonly used before visiting the sub nodes.
-            AllPreVisit             = (ConvertVectorCompare | ConvertImageAccess | ConvertLog10),
+            AllPreVisit                 = (ConvertVectorCompare | ConvertImageAccess | ConvertLog10 | ConvertSamplerBufferAccess),
 
             // All conversion flags commonly used after visiting the sub nodes.
-            AllPostVisit            = (ConvertVectorSubscripts),
+            AllPostVisit                = (ConvertVectorSubscripts),
 
             // All conversion flags.
-            All                     = (~0u),
+            All                         = (~0u),
         };
 
         // Converts the expressions in the specified AST.
@@ -92,6 +93,10 @@ class ExprConverter : public Visitor
         void ConvertExprImageAccessAssign(ExprPtr& expr, AssignExpr* assignExpr);
         void ConvertExprImageAccessArray(ExprPtr& expr, ArrayExpr* arrayExpr, AssignExpr* assignExpr = nullptr);
         
+        // Converts the expression from a sampler buffer access to the texelFetch intrinsic call (e.g. "buffer[2]" -> "texelFetch(buffer, 2)").
+        void ConvertExprSamplerBufferAccess(ExprPtr& expr);
+        void ConvertExprSamplerBufferAccessArray(ExprPtr& expr, ArrayExpr* arrayExpr);
+
         // Converts the expression by moving its sub expression into a bracket (e.g. "-+x" -> "-(+x)").
         void ConvertExprIntoBracket(ExprPtr& expr);
 

--- a/src/Compiler/AST/Visitor/ReflectionAnalyzer.cpp
+++ b/src/Compiler/AST/Visitor/ReflectionAnalyzer.cpp
@@ -159,7 +159,7 @@ IMPLEMENT_VISIT_PROC(BufferDeclStmnt)
                     bindingSlot.location    = GetBindingPoint(bufferDecl->slotRegisters);
                 };
 
-                if (IsTextureBufferType(ast->typeDenoter->bufferType))
+                if (!IsStorageBufferType(ast->typeDenoter->bufferType))
                     data_->textures.push_back(bindingSlot);
                 else
                     data_->storageBuffers.push_back(bindingSlot);

--- a/src/Compiler/Backend/GLSL/GLSLConverter.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.cpp
@@ -1023,8 +1023,11 @@ void GLSLConverter::ConvertIntrinsicCallImageStore(CallExpr* ast)
             const auto& typeDen = arg0ArrayExpr->prefixExpr->GetTypeDenoter()->GetAliased();
             if (auto bufferTypeDen = typeDen.As<BufferTypeDenoter>())
             {
-                if (auto baseBufferTypeDen = bufferTypeDen->As<BaseTypeDenoter>())
-                    dataType = baseBufferTypeDen->dataType;
+				if (bufferTypeDen->genericTypeDenoter != nullptr)
+				{
+					if (auto baseBufferTypeDen = bufferTypeDen->genericTypeDenoter->As<BaseTypeDenoter>())
+						dataType = baseBufferTypeDen->dataType;
+				}
             }
         }
         else
@@ -1032,8 +1035,11 @@ void GLSLConverter::ConvertIntrinsicCallImageStore(CallExpr* ast)
             const auto& typeDen = arg0Expr->GetTypeDenoter()->GetAliased();
             if (auto bufferTypeDen = typeDen.As<BufferTypeDenoter>())
             {
-                if (auto baseBufferTypeDen = bufferTypeDen->As<BaseTypeDenoter>())
-                    dataType = baseBufferTypeDen->dataType;
+				if (bufferTypeDen->genericTypeDenoter != nullptr)
+				{
+					if (auto baseBufferTypeDen = bufferTypeDen->genericTypeDenoter->As<BaseTypeDenoter>())
+						dataType = baseBufferTypeDen->dataType;
+				}
             }
         }
 

--- a/src/Compiler/Backend/GLSL/GLSLConverter.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.cpp
@@ -809,6 +809,9 @@ void GLSLConverter::ConvertIntrinsicCall(CallExpr* ast)
         case Intrinsic::Texture_SampleLevel_5:
             ConvertIntrinsicCallTextureSampleLevel(ast);
             break;
+        case Intrinsic::Image_Store:
+            ConvertIntrinsicCallImageStore(ast);
+            break;
         default:
             break;
     }
@@ -843,6 +846,7 @@ static int GetTextureDimFromExpr(Expr* expr, const AST* ast = nullptr)
             /* Determine vector size for texture intrinsic parameters by texture buffer type */
             switch (bufferTypeDen->bufferType)
             {
+                case BufferType::Buffer:
                 case BufferType::Texture1D:
                     return 1;
                 case BufferType::Texture1DArray:
@@ -1001,6 +1005,44 @@ void GLSLConverter::ConvertIntrinsicCallImageAtomic(CallExpr* ast)
                 }
             }
         }
+    }
+}
+
+void GLSLConverter::ConvertIntrinsicCallImageStore(CallExpr* ast)
+{
+    /* Cast input value argument to 4 component vector */
+    auto& args = ast->arguments;
+
+    if (args.size() >= 3)
+    {
+        DataType dataType = DataType::Float;
+
+        const auto& arg0Expr = args.front();
+        if (auto arg0ArrayExpr = arg0Expr->As<ArrayExpr>())
+        {
+            const auto& typeDen = arg0ArrayExpr->prefixExpr->GetTypeDenoter()->GetAliased();
+            if (auto bufferTypeDen = typeDen.As<BufferTypeDenoter>())
+            {
+                if (auto baseBufferTypeDen = bufferTypeDen->As<BaseTypeDenoter>())
+                    dataType = baseBufferTypeDen->dataType;
+            }
+        }
+        else
+        {
+            const auto& typeDen = arg0Expr->GetTypeDenoter()->GetAliased();
+            if (auto bufferTypeDen = typeDen.As<BufferTypeDenoter>())
+            {
+                if (auto baseBufferTypeDen = bufferTypeDen->As<BaseTypeDenoter>())
+                    dataType = baseBufferTypeDen->dataType;
+            }
+        }
+
+        if(IsIntType(dataType))
+            exprConverter_.ConvertExprIfCastRequired(args[2], DataType::Int4, true);
+        else if(IsUIntType(dataType))
+            exprConverter_.ConvertExprIfCastRequired(args[2], DataType::UInt4, true);
+        else
+            exprConverter_.ConvertExprIfCastRequired(args[2], DataType::Float4, true);
     }
 }
 

--- a/src/Compiler/Backend/GLSL/GLSLConverter.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.cpp
@@ -1023,11 +1023,11 @@ void GLSLConverter::ConvertIntrinsicCallImageStore(CallExpr* ast)
             const auto& typeDen = arg0ArrayExpr->prefixExpr->GetTypeDenoter()->GetAliased();
             if (auto bufferTypeDen = typeDen.As<BufferTypeDenoter>())
             {
-				if (bufferTypeDen->genericTypeDenoter != nullptr)
-				{
-					if (auto baseBufferTypeDen = bufferTypeDen->genericTypeDenoter->As<BaseTypeDenoter>())
-						dataType = baseBufferTypeDen->dataType;
-				}
+                if (bufferTypeDen->genericTypeDenoter != nullptr)
+                {
+                    if (auto baseBufferTypeDen = bufferTypeDen->genericTypeDenoter->As<BaseTypeDenoter>())
+                        dataType = baseBufferTypeDen->dataType;
+                }
             }
         }
         else
@@ -1035,11 +1035,11 @@ void GLSLConverter::ConvertIntrinsicCallImageStore(CallExpr* ast)
             const auto& typeDen = arg0Expr->GetTypeDenoter()->GetAliased();
             if (auto bufferTypeDen = typeDen.As<BufferTypeDenoter>())
             {
-				if (bufferTypeDen->genericTypeDenoter != nullptr)
-				{
-					if (auto baseBufferTypeDen = bufferTypeDen->genericTypeDenoter->As<BaseTypeDenoter>())
-						dataType = baseBufferTypeDen->dataType;
-				}
+                if (bufferTypeDen->genericTypeDenoter != nullptr)
+                {
+                    if (auto baseBufferTypeDen = bufferTypeDen->genericTypeDenoter->As<BaseTypeDenoter>())
+                        dataType = baseBufferTypeDen->dataType;
+                }
             }
         }
 

--- a/src/Compiler/Backend/GLSL/GLSLConverter.h
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.h
@@ -104,6 +104,7 @@ class GLSLConverter : public Converter
         void ConvertIntrinsicCallTextureSample(CallExpr* ast);
         void ConvertIntrinsicCallTextureSampleLevel(CallExpr* ast);
         void ConvertIntrinsicCallImageAtomic(CallExpr* ast);
+        void ConvertIntrinsicCallImageStore(CallExpr* ast);
 
         void ConvertFunctionCall(CallExpr* ast);
 

--- a/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
@@ -2645,7 +2645,7 @@ void GLSLGenerator::WriteBufferDecl(BufferDecl* bufferDecl)
 {
     if (bufferDecl->flags(AST::isReachable))
     {
-        if (IsTextureBufferType(bufferDecl->GetBufferType()))
+        if (!IsStorageBufferType(bufferDecl->GetBufferType()))
             WriteBufferDeclTexture(bufferDecl);
         else
             WriteBufferDeclStorageBuffer(bufferDecl);

--- a/src/Compiler/Backend/GLSL/GLSLKeywords.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLKeywords.cpp
@@ -214,11 +214,11 @@ static std::map<BufferType, std::string> GenerateBufferTypeMap()
 
     return
     {
-        { T::Buffer,                  "buffer"           },
+        { T::Buffer,                  "samplerBuffer"    },
         { T::StructuredBuffer,        "buffer"           },
         { T::ByteAddressBuffer,       "buffer"           },
 
-        { T::RWBuffer,                "buffer"           },
+        { T::RWBuffer,                "imageBuffer"      },
         { T::RWStructuredBuffer,      "buffer"           },
         { T::RWByteAddressBuffer,     "buffer"           },
         { T::AppendStructuredBuffer,  "buffer"           },
@@ -257,11 +257,11 @@ static std::map<BufferType, std::string> GenerateBufferTypeMapVKSL()
 
     return
     {
-        { T::Buffer,                  "buffer"           },
+        { T::Buffer,                  "samplerBuffer"    },
         { T::StructuredBuffer,        "buffer"           },
         { T::ByteAddressBuffer,       "buffer"           },
 
-        { T::RWBuffer,                "buffer"           },
+        { T::RWBuffer,                "imageBuffer"      },
         { T::RWStructuredBuffer,      "buffer"           },
         { T::RWByteAddressBuffer,     "buffer"           },
         { T::AppendStructuredBuffer,  "buffer"           },


### PR DESCRIPTION
Hi. As we discussed for a bit previously, `Buffer` and `RWBuffer` no longer map to `buffer` (SSBO) in GLSL, and instead map to `samplerBuffer` and `imageBuffer`, respectively. `imageBuffer` is treated the same as image textures, while `samplerBuffer` is treated the same as read-only textures (except with no support for sampling, and support for operator[]).