### PR TITLE
Automatic binding slot generation

### DIFF
--- a/inc/Xsc/Xsc.h
+++ b/inc/Xsc/Xsc.h
@@ -159,6 +159,12 @@ struct Options
 
     //! If true, the timings of the different compilation processes are written to the log output. By default false.
     bool showTimes                  = false;
+
+    //! If true, binding slots for all buffer types will be generated sequentially, starting with index at autoBindingOffset. By default false.
+    bool autoBinding                = false;
+
+    //! Index to start generating binding slots from. Only relevant if autoBinding is enabled. By default 0.
+    int autoBindingSlotOffset       = 0;
 };
 
 //! Name mangling descriptor structure for shader input/output variables (also referred to as "varyings"), temporary variables, and reserved keywords.

--- a/src/Compiler/AST/ASTFactory.cpp
+++ b/src/Compiler/AST/ASTFactory.cpp
@@ -234,6 +234,16 @@ ArrayExprPtr MakeArrayExpr(const ExprPtr& prefixExpr, const std::vector<int>& ar
     return ast;
 }
 
+RegisterPtr MakeRegister(int slot)
+{
+    auto ast = MakeAST<Register>();
+    ast->registerType = RegisterType::Undefined;
+    ast->shaderTarget = ShaderTarget::Undefined;
+    ast->slot = slot;
+
+    return ast;
+}
+
 BracketExprPtr MakeBracketExpr(const ExprPtr& expr)
 {
     auto ast = MakeASTWithOrigin<BracketExpr>(expr);

--- a/src/Compiler/AST/ASTFactory.h
+++ b/src/Compiler/AST/ASTFactory.h
@@ -57,6 +57,8 @@ ObjectExprPtr                   MakeObjectExpr(Decl* symbolRef);
 
 ArrayExprPtr                    MakeArrayExpr(const ExprPtr& prefixExpr, const std::vector<int>& arrayIndices);
 
+RegisterPtr                     MakeRegister(int slot);
+
 // Makes a new bracket expression with the specified sub expression (source area is copied).
 BracketExprPtr                  MakeBracketExpr(const ExprPtr& expr);
 

--- a/src/Compiler/Backend/GLSL/GLSLConverter.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.cpp
@@ -53,6 +53,8 @@ void GLSLConverter::ConvertASTPrimary(Program& program, const ShaderInput& input
     shaderTarget_       = inputDesc.shaderTarget;
     options_            = outputDesc.options;
     isVKSL_             = IsLanguageVKSL(outputDesc.shaderVersion);
+    autoBindings_       = outputDesc.options.autoBinding;
+    autoBindingSlot_    = outputDesc.options.autoBindingSlotOffset;
 
     /* Convert type of specific semantics */
     TypeConverter typeConverter;
@@ -215,12 +217,24 @@ IMPLEMENT_VISIT_PROC(VarDecl)
 
 IMPLEMENT_VISIT_PROC(BufferDecl)
 {
+    if (autoBindings_)
+    {
+        ast->slotRegisters.clear();
+        ast->slotRegisters.push_back(ASTFactory::MakeRegister(autoBindingSlot_++));
+    }
+
     RegisterDeclIdent(ast);
     VISIT_DEFAULT(BufferDecl);
 }
 
 IMPLEMENT_VISIT_PROC(SamplerDecl)
 {
+    if (autoBindings_)
+    {
+        ast->slotRegisters.clear();
+        ast->slotRegisters.push_back(ASTFactory::MakeRegister(autoBindingSlot_++));
+    }
+
     RegisterDeclIdent(ast);
     VISIT_DEFAULT(SamplerDecl);
 }
@@ -279,6 +293,12 @@ IMPLEMENT_VISIT_PROC(FunctionDecl)
 
 IMPLEMENT_VISIT_PROC(UniformBufferDecl)
 {
+    if(autoBindings_)
+    {
+        ast->slotRegisters.clear();
+        ast->slotRegisters.push_back(ASTFactory::MakeRegister(autoBindingSlot_++));
+    }
+
     Visit(ast->slotRegisters);
     VisitScopedStmntList(ast->localStmnts);
 }

--- a/src/Compiler/Backend/GLSL/GLSLConverter.h
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.h
@@ -144,6 +144,8 @@ class GLSLConverter : public Converter
 
         Options                     options_;
         bool                        isVKSL_             = false;
+        bool                        autoBindings_       = false;
+        int                         autoBindingSlot_    = 0;
 
         /*
         List of all variables with reserved identifiers that come from a structure that must be resolved.

--- a/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
@@ -62,6 +62,7 @@ void GLSLGenerator::GenerateCodePrimary(
     allowLineMarks_     = outputDesc.formatting.lineMarks;
     compactWrappers_    = outputDesc.formatting.compactWrappers;
     alwaysBracedScopes_ = outputDesc.formatting.alwaysBracedScopes;
+    autoBinding_        = outputDesc.options.autoBinding;
 
     for (const auto& s : outputDesc.vertexSemantics)
     {
@@ -1229,7 +1230,7 @@ void GLSLGenerator::WriteLayoutGlobalOut(const std::initializer_list<LayoutEntry
 
 void GLSLGenerator::WriteLayoutBinding(const std::vector<RegisterPtr>& slotRegisters)
 {
-    if (explicitBinding_)
+    if (explicitBinding_ || autoBinding_)
     {
         if (auto slotRegister = Register::GetForTarget(slotRegisters, GetShaderTarget()))
             Write("binding = " + std::to_string(slotRegister->slot));

--- a/src/Compiler/Backend/GLSL/GLSLGenerator.h
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.h
@@ -299,6 +299,7 @@ class GLSLGenerator : public Generator
         bool                                    allowLineMarks_         = false;
         bool                                    compactWrappers_        = true;
         bool                                    alwaysBracedScopes_     = false;
+        bool                                    autoBinding_            = false;
 
         bool                                    isInsideInterfaceBlock_ = false;
 };

--- a/src/Debugger/DebuggerView.cpp
+++ b/src/Debugger/DebuggerView.cpp
@@ -214,6 +214,8 @@ void DebuggerView::CreateLayoutPropertyGridOptions(wxPropertyGrid& pg)
     pg.Append(new wxBoolProperty("Row-Major Alignment", "rowMajor"));
     pg.Append(new wxBoolProperty("Obfuscate", "obfuscate"));
     pg.Append(new wxBoolProperty("Show AST", "showAST"));
+    pg.Append(new wxBoolProperty("Automatic binding", "autoBinding"));
+    pg.Append(new wxIntProperty("Automatic binding slot offset", "autoBindingSlotOffset"));
 }
 
 void DebuggerView::CreateLayoutPropertyGridFormatting(wxPropertyGrid& pg)
@@ -432,6 +434,10 @@ void DebuggerView::OnPropertyGridChange(wxPropertyGridEvent& event)
         shaderOutput_.options.obfuscate = ValueBool();
     else if (name == "showAST")
         shaderOutput_.options.showAST = ValueBool();
+    else if (name == "autoBinding")
+        shaderOutput_.options.autoBinding = ValueBool();
+    else if (name == "autoBindingSlotOffset")
+        shaderOutput_.options.autoBindingSlotOffset = ValueInt();
 
     /* --- Formatting --- */
     else if (name == "blanks")

--- a/src/Shell/Command.cpp
+++ b/src/Shell/Command.cpp
@@ -928,6 +928,51 @@ void BindingCommand::Run(CommandLine& cmdLine, ShellState& state)
     state.outputDesc.options.explicitBinding = cmdLine.AcceptBoolean(true);
 }
 
+/*
+ * AutoBindingCommand class
+ */
+
+std::vector<Command::Identifier> AutoBindingCommand::Idents() const
+{
+    return { { "-AB" }, { "--auto-bind" } };
+}
+
+HelpDescriptor AutoBindingCommand::Help() const
+{
+    return
+    {
+        "-AB, --auto-bind [" + CommandLine::GetBooleanOption() + "]",
+        "Enables/disables automatic binding slot generation; default=" + CommandLine::GetBooleanFalse()
+    };
+}
+
+void AutoBindingCommand::Run(CommandLine& cmdLine, ShellState& state)
+{
+    state.outputDesc.options.autoBinding = cmdLine.AcceptBoolean(true);
+}
+
+/*
+ * AutoBindingSlotOffsetCommand class
+ */
+
+std::vector<Command::Identifier> AutoBindingSlotOffsetCommand::Idents() const
+{
+    return { { "--auto-bind-offset" } };
+}
+
+HelpDescriptor AutoBindingSlotOffsetCommand::Help() const
+{
+    return
+    {
+        "--auto-bind-offset OFFSET",
+        "Offset to apply to slots when automatic binding slot generation is enabled; default=0"
+    };
+}
+
+void AutoBindingSlotOffsetCommand::Run(CommandLine& cmdLine, ShellState& state)
+{
+    state.outputDesc.options.autoBindingSlotOffset = std::stoi(cmdLine.Accept());
+}
 
 /*
  * CommentCommand class

--- a/src/Shell/Command.h
+++ b/src/Shell/Command.h
@@ -99,6 +99,8 @@ DECL_SHELL_COMMAND( WrapperCommand               );
 DECL_SHELL_COMMAND( UnrollInitializerCommand     );
 DECL_SHELL_COMMAND( ObfuscateCommand             );
 DECL_SHELL_COMMAND( RowMajorAlignmentCommand     );
+DECL_SHELL_COMMAND( AutoBindingCommand           );
+DECL_SHELL_COMMAND( AutoBindingSlotOffsetCommand );
 
 DECL_SHELL_COMMAND( FormatBlanksCommand          );
 DECL_SHELL_COMMAND( FormatLineMarksCommand       );


### PR DESCRIPTION
Added a way to generate GLSL binding slots (`layout(binding = X)`) automatically (sequentially). Explicit bindings based on HLSL registers are nice, but recently I have found explicit bindings of any kind extremely frustrating in practice. 

In complex apps you end up having shaders broken up into smaller pieces in order to re-use them. Those smaller pieces often contain buffers or uniform blocks of their own, and you #include them together with other shaders that are also doing the same. If explicit bindings are used you need to ensure that no binding slots in an #include conflicts with any other include, which is error prone, ugly and just plain unnecessary.

I added the following:
 - --auto-bind option to enable automatic bindings (off by default)
 - --auto-bind-offset option to specify an offset from which to start assigning slots from

The offset is needed in order to ensure different shader stages can receive separate bindings (e.g. vertex shader might use up bindings 0-3, and fragment shader can then continue from slot 4 and up). This is up to the caller to set up. Last time I checked glslang also handled this via offsets.

Almost all the logic happens in GLSLConverter where I just override any existing register slots with auto-generated ones. The rest is just exposing the commands to CLI and GUI.