### PR TITLE
Added .editorconfig to enforce the use of spaces in supported editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root=true
+[*]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
So Visual Studio and other IDEs can properly switch between spaces & tabs on a per-project basis, and hopefully stop me from checking in more tabs :)