### PR TITLE
Fix a crash when converting a plain 'return' statement

### DIFF
--- a/src/Compiler/Backend/GLSL/GLSLConverter.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.cpp
@@ -444,7 +444,7 @@ IMPLEMENT_VISIT_PROC(ReturnStmnt)
     VISIT_DEFAULT(ReturnStmnt);
 
     /* Check for cast expressions in entry-point return statements */
-    if (InsideEntryPoint())
+    if (InsideEntryPoint() && ast->expr != nullptr)
     {
         if (auto castExpr = AST::GetAs<CastExpr>(ast->expr->FindFirstOf(AST::Types::CastExpr)))
         {


### PR DESCRIPTION
If a plain (no expression) `return` statement was used, an access violation was triggered trying to access a null pointer. Just added a null check.