### PR TITLE
Added support for shadow samplers

### DIFF
--- a/src/Compiler/AST/AST.h
+++ b/src/Compiler/AST/AST.h
@@ -561,6 +561,11 @@ struct BufferDecl : public Decl
 {
     AST_INTERFACE(BufferDecl);
 
+    FLAG_ENUM
+    {
+        FLAG(isUsedForCompare,     2), // This variable is used in a texture compare operation
+    };
+
     TypeDenoterPtr DeriveTypeDenoter(const TypeDenoter* expectedTypeDenoter) override;
 
     // Returns the buffer type of the parent's node type denoter.

--- a/src/Compiler/AST/ASTEnums.cpp
+++ b/src/Compiler/AST/ASTEnums.cpp
@@ -834,6 +834,52 @@ bool IsSamplerTypeArray(const SamplerType t)
     return ((t >= SamplerType::Sampler1DArray && t <= SamplerType::SamplerCubeArray) || t == SamplerType::Sampler2DMSArray);
 }
 
+SamplerType TextureTypeToSamplerType(const BufferType t)
+{
+    switch (t)
+    {
+    case BufferType::Texture1D:
+        return SamplerType::Sampler1D;
+    case BufferType::Texture1DArray:
+        return SamplerType::Sampler1DArray;
+    case BufferType::Texture2D:
+        return SamplerType::Sampler2D;
+    case BufferType::Texture2DArray:
+        return SamplerType::Sampler2DArray;
+    case BufferType::Texture3D:
+        return SamplerType::Sampler3D;
+    case BufferType::TextureCube:
+        return SamplerType::SamplerCube;
+    case BufferType::TextureCubeArray:
+        return SamplerType::SamplerCubeArray;
+    default:
+        return SamplerType::Undefined;
+    }
+}
+
+SamplerType SamplerTypeToShadowSamplerType(const SamplerType t)
+{
+    switch (t)
+    {
+    case SamplerType::Sampler1D:
+        return SamplerType::Sampler1DShadow;
+    case SamplerType::Sampler1DArray:
+        return SamplerType::Sampler1DArrayShadow;
+    case SamplerType::Sampler2D:
+        return SamplerType::Sampler2DShadow;
+    case SamplerType::Sampler2DArray:
+        return SamplerType::Sampler2DArrayShadow;
+    case SamplerType::Sampler2DRect:
+        return SamplerType::Sampler2DRectShadow;
+    case SamplerType::SamplerCube:
+        return SamplerType::SamplerCubeShadow;
+    case SamplerType::SamplerCubeArray:
+        return SamplerType::SamplerCubeArrayShadow;
+    default:
+        return SamplerType::Undefined;
+    }
+}
+
 
 /* ----- RegisterType Enum ----- */
 

--- a/src/Compiler/AST/ASTEnums.h
+++ b/src/Compiler/AST/ASTEnums.h
@@ -486,6 +486,12 @@ bool IsSamplerTypeShadow(const SamplerType t);
 // Returns true if the specified sampler type is an array sampler (e.g. Sampler1DArray).
 bool IsSamplerTypeArray(const SamplerType t);
 
+// Maps a texture type to an appropriate sampler type
+SamplerType TextureTypeToSamplerType(const BufferType t);
+
+// Converts a non-shadow sampler variant into a shadow one, if possible.
+SamplerType SamplerTypeToShadowSamplerType(const SamplerType t);
+
 
 /* ----- RegisterType Enum ----- */
 

--- a/src/Compiler/AST/ASTFactory.cpp
+++ b/src/Compiler/AST/ASTFactory.cpp
@@ -47,26 +47,6 @@ CallExprPtr MakeIntrinsicCallExpr(
     return ast;
 }
 
-static SamplerType TextureTypeToSamplerType(const BufferType t)
-{
-    switch (t)
-    {
-        case BufferType::Texture1D:
-        case BufferType::Texture1DArray:
-            return SamplerType::Sampler1D;
-        case BufferType::Texture2D:
-        case BufferType::Texture2DArray:
-            return SamplerType::Sampler2D;
-        case BufferType::Texture3D:
-            return SamplerType::Sampler3D;
-        case BufferType::TextureCube:
-        case BufferType::TextureCubeArray:
-            return SamplerType::SamplerCube;
-        default:
-            return SamplerType::Undefined;
-    }
-}
-
 CallExprPtr MakeTextureSamplerBindingCallExpr(const ExprPtr& textureObjectExpr, const ExprPtr& samplerObjectExpr)
 {
     auto ast = MakeAST<CallExpr>();

--- a/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
@@ -2655,8 +2655,21 @@ void GLSLGenerator::WriteBufferDecl(BufferDecl* bufferDecl)
 
 void GLSLGenerator::WriteBufferDeclTexture(BufferDecl* bufferDecl)
 {
-    /* Determine GLSL sampler type (or VKSL texture type) */
-    auto bufferTypeKeyword = BufferTypeToKeyword(bufferDecl->GetBufferType(), bufferDecl->declStmntRef);
+    const std::string* bufferTypeKeyword;
+    if(bufferDecl->flags(BufferDecl::isUsedForCompare) && !IsVKSL())
+    {
+        /* Convert type to a shadow sampler type */
+        SamplerType samplerType = TextureTypeToSamplerType(bufferDecl->GetBufferType());
+        SamplerType shadowSamplerType = SamplerTypeToShadowSamplerType(samplerType);
+
+        bufferTypeKeyword = SamplerTypeToKeyword(shadowSamplerType, bufferDecl->declStmntRef);
+    }
+    else
+    {
+        /* Determine GLSL sampler type (or VKSL texture type) */
+        bufferTypeKeyword = BufferTypeToKeyword(bufferDecl->GetBufferType(), bufferDecl->declStmntRef);
+    }
+
     if (!bufferTypeKeyword)
         return;
 

--- a/src/Compiler/Backend/GLSL/GLSLKeywords.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLKeywords.cpp
@@ -329,7 +329,7 @@ static std::map<SamplerType, std::string> GenerateSamplerTypeMap()
         { T::Sampler2DArrayShadow,   "sampler2DArrayShadow"   },
         { T::SamplerCubeArrayShadow, "samplerCubeArrayShadow" },
         { T::SamplerState,           "sampler"                }, // Only for Vulkan
-        { T::SamplerComparisonState, "sampler"                }, // Only for Vulkan
+        { T::SamplerComparisonState, "samplerShadow"          }, // Only for Vulkan
     };
 }
 

--- a/src/Compiler/Frontend/HLSL/HLSLAnalyzer.cpp
+++ b/src/Compiler/Frontend/HLSL/HLSLAnalyzer.cpp
@@ -867,6 +867,13 @@ void HLSLAnalyzer::AnalyzeCallExprIntrinsic(CallExpr* callExpr, const HLSLIntrin
             {
                 /* Analyze member function call with buffer prefix type */
                 AnalyzeCallExprIntrinsicFromBufferType(callExpr, bufferTypeDen->bufferType);
+
+                /* Mark buffers used in compare intrinsics */
+                if (IsTextureCompareIntrinsic(intrinsic))
+                {
+                    if (auto bufferDecl = bufferTypeDen->bufferDeclRef)
+                        bufferDecl->flags << BufferDecl::isUsedForCompare;
+                }
             }
             else
             {


### PR DESCRIPTION
Added support for generating shadow samplers, when objects are detected to be used in `SampleCmp` or `GatherCmp*` intrinsics.

`GLSLGenerator` runs the new analyzer `ShadowSamplerAnalyzer` which looks for those specific intrinsics and marks the buffer declarations that those intrinsics are used on. 

`GLSLGenerator` then checks for such declarations and writes the shadow sampler type instead of the normal sampler type. This not done for VKSL as it uses separate sampler & texture types, and a more direct mapping between them is possible.

I re-used the `TextureTypeToSamplerType` function used by `ASTFactory` and modified it so it returns aarry sampler types for texture array types. I am not sure if there was a reason the non-array sampler types were being returned for array textures. I couldn't see one, but if there was then I probably broke something.


