### PR TITLE
Added support for gl_PerVertex block redeclaration

### DIFF
--- a/inc/Xsc/Xsc.h
+++ b/inc/Xsc/Xsc.h
@@ -168,6 +168,9 @@ struct Options
 
     //! If true, the timings of the different compilation processes are written to the log output. By default false.
     bool    showTimes               = false;
+
+    //! If true, generates code will support the ARB_separate_shader_objects extension. By default false.
+    bool    supportSeparateShaders  = false;
 };
 
 //! Name mangling descriptor structure for shader input/output variables (also referred to as "varyings"), temporary variables, and reserved keywords.

--- a/src/Compiler/Backend/GLSL/GLSLExtensionAgent.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLExtensionAgent.cpp
@@ -57,7 +57,7 @@ static OutputShaderVersion GetMinGLSLVersionForTarget(const ShaderTarget shaderT
 
 std::set<std::string> GLSLExtensionAgent::DetermineRequiredExtensions(
     Program& program, OutputShaderVersion& targetGLSLVersion, const ShaderTarget shaderTarget,
-    bool allowExtensions, bool explicitBinding, const OnReportProc& onReportExtension)
+    bool allowExtensions, bool explicitBinding, bool supportSeparateShaders, const OnReportProc& onReportExtension)
 {
     /* Store parameters */
     shaderTarget_       = shaderTarget;
@@ -85,6 +85,12 @@ std::set<std::string> GLSLExtensionAgent::DetermineRequiredExtensions(
 
         default:
             break;
+    }
+
+    if (supportSeparateShaders)
+    {
+        if (shaderTarget != ShaderTarget::FragmentShader && shaderTarget != ShaderTarget::ComputeShader)
+            AcquireExtension(E_GL_ARB_separate_shader_objects);
     }
 
     /* Visit AST program */

--- a/src/Compiler/Backend/GLSL/GLSLExtensionAgent.h
+++ b/src/Compiler/Backend/GLSL/GLSLExtensionAgent.h
@@ -37,6 +37,7 @@ class GLSLExtensionAgent : private Visitor
             const ShaderTarget shaderTarget,
             bool allowExtensions,
             bool explicitBinding,
+            bool supportSeparateShaders,
             const OnReportProc& onReportExtension = nullptr
         );
 

--- a/src/Compiler/Backend/GLSL/GLSLGenerator.h
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.h
@@ -157,6 +157,11 @@ class GLSLGenerator : public Generator
         bool WriteGlobalLayoutsFragment(const Program::LayoutFragmentShader& layout);
         bool WriteGlobalLayoutsCompute(const Program::LayoutComputeShader& layout);
 
+        /* ----- Built-in block redeclarations ----- */
+
+        void WriteBuiltinBlockRedeclarations();
+        void WritePerVertexBlockRedeclaration(bool input, const std::string& name = "");
+
         /* ----- Layout ----- */
 
         void WriteLayout(const std::initializer_list<LayoutEntryFunctor>& entryFunctors);
@@ -166,6 +171,7 @@ class GLSLGenerator : public Generator
         void WriteLayoutGlobalOut(const std::initializer_list<LayoutEntryFunctor>& entryFunctors, const LayoutEntryFunctor& varFunctor = nullptr);
         void WriteLayoutBinding(const std::vector<RegisterPtr>& slotRegisters);
         void WriteLayoutImageFormat(const TypeDenoterPtr& typeDenoter, const AST* ast = nullptr);
+
 
         /* ----- Input semantics ----- */
 
@@ -299,6 +305,7 @@ class GLSLGenerator : public Generator
         bool                                    allowLineMarks_         = false;
         bool                                    compactWrappers_        = false;
         bool                                    alwaysBracedScopes_     = false;
+        bool                                    supportSeparateShaders_ = false;
 
         bool                                    isInsideInterfaceBlock_ = false;
 };

--- a/src/Debugger/DebuggerView.cpp
+++ b/src/Debugger/DebuggerView.cpp
@@ -216,6 +216,7 @@ void DebuggerView::CreateLayoutPropertyGridOptions(wxPropertyGrid& pg)
     pg.Append(new wxBoolProperty("Show AST", "showAST"));
     pg.Append(new wxBoolProperty("Auto. Binding", "autoBinding"));
     pg.Append(new wxIntProperty("Auto. Binding Start Slot", "autoBindingStartSlot"));
+    pg.Append(new wxBoolProperty("Separate Shaders Support", "separateShaders"));
 }
 
 void DebuggerView::CreateLayoutPropertyGridFormatting(wxPropertyGrid& pg)
@@ -439,6 +440,8 @@ void DebuggerView::OnPropertyGridChange(wxPropertyGridEvent& event)
         shaderOutput_.options.autoBinding = ValueBool();
     else if (name == "autoBindingStartSlot")
         shaderOutput_.options.autoBindingStartSlot = ValueInt();
+    else if (name == "separateShaders")
+        shaderOutput_.options.supportSeparateShaders = ValueBool();
 
     /* --- Formatting --- */
     else if (name == "blanks")

--- a/src/Shell/Command.cpp
+++ b/src/Shell/Command.cpp
@@ -1246,6 +1246,30 @@ void NameManglingCommand::Run(CommandLine& cmdLine, ShellState& state)
         throw std::invalid_argument("invalid name-mangling type '" + type + "'");
 }
 
+/*
+ * SeparateShadersCommand class
+ */
+
+std::vector<Command::Identifier> SeparateShadersCommand::Idents() const
+{
+    return{ { "--separate-shaders" } };
+}
+
+HelpDescriptor SeparateShadersCommand::Help() const
+{
+    return
+    {
+        "--separate-shaders [" + CommandLine::GetBooleanOption() + "]",
+        "Ensures generated shaders are compatible with ARB_separate_shader_objects extension; default = " + CommandLine::GetBooleanFalse()
+    };
+}
+
+void SeparateShadersCommand::Run(CommandLine& cmdLine, ShellState& state)
+{
+    state.outputDesc.options.supportSeparateShaders = cmdLine.AcceptBoolean(true);
+}
+
+
 
 } // /namespace Util
 

--- a/src/Shell/Command.h
+++ b/src/Shell/Command.h
@@ -104,6 +104,7 @@ DECL_SHELL_COMMAND( FormattingCommand            );
 DECL_SHELL_COMMAND( IndentCommand                );
 DECL_SHELL_COMMAND( PrefixCommand                );
 DECL_SHELL_COMMAND( NameManglingCommand          );
+DECL_SHELL_COMMAND( SeparateShadersCommand       );
 
 #undef DECL_SHELL_COMMAND
 

--- a/src/Shell/CommandFactory.cpp
+++ b/src/Shell/CommandFactory.cpp
@@ -86,7 +86,8 @@ CommandFactory::CommandFactory()
         FormattingCommand,
         IndentCommand,
         PrefixCommand,
-        NameManglingCommand
+        NameManglingCommand,
+        SeparateShadersCommand
     >();
 }
 


### PR DESCRIPTION
In order to support compilation of separate shader programs (e.g. via `glCreateShaderProgram` in OpenGL), `gl_PerVertex` block must be explicitly declared in vertex, tess. control, tess. evaluation and geometry shaders. Otherwise the compilation fails with:

> error C7592: ARB_separate_shader_objects requires built-in block gl_PerVertex to be redeclared before accessing its members

I've added:
- A flag to CLI and debugger to toggle generation of such blocks
- Generation code in `GLSLGenerator` that parses entry point input/output semantics and return value, looks for semantics that are part of `gl_PerVertex` and generates an appropriate `gl_PerVertex` definition.
- Code that registers the `ARB_separate_shader_objects` extension when the separate shader option is turned on