### PR TITLE
Fixing a few issues with texelFetch calls

### DIFF
--- a/src/Compiler/AST/ASTFactory.cpp
+++ b/src/Compiler/AST/ASTFactory.cpp
@@ -216,6 +216,16 @@ ArrayExprPtr MakeArrayExpr(const ExprPtr& prefixExpr, const std::vector<int>& ar
     return ast;
 }
 
+ArrayExprPtr MakeArrayExpr(const ExprPtr& prefixExpr, const std::vector<ExprPtr>& arrayIndices)
+{
+    auto ast = MakeAST<ArrayExpr>();
+    {
+        ast->prefixExpr = prefixExpr;
+        ast->arrayIndices = arrayIndices;
+    }
+    return ast;
+}
+
 RegisterPtr MakeRegister(int slot, const RegisterType registerType)
 {
     auto ast = MakeAST<Register>();

--- a/src/Compiler/AST/ASTFactory.h
+++ b/src/Compiler/AST/ASTFactory.h
@@ -56,6 +56,7 @@ ObjectExprPtr                   MakeObjectExpr(const std::string& ident, Decl* s
 ObjectExprPtr                   MakeObjectExpr(Decl* symbolRef);
 
 ArrayExprPtr                    MakeArrayExpr(const ExprPtr& prefixExpr, const std::vector<int>& arrayIndices);
+ArrayExprPtr                    MakeArrayExpr(const ExprPtr& prefixExpr, const std::vector<ExprPtr>& arrayIndices);
 
 RegisterPtr                     MakeRegister(int slot, const RegisterType registerType = RegisterType::Undefined);
 

--- a/src/Compiler/Backend/GLSL/GLSLConverter.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.cpp
@@ -816,6 +816,11 @@ void GLSLConverter::ConvertIntrinsicCall(CallExpr* ast)
         case Intrinsic::Texture_SampleLevel_5:
             ConvertIntrinsicCallTextureSampleLevel(ast);
             break;
+        case Intrinsic::Texture_Load_1:
+        case Intrinsic::Texture_Load_2:
+        case Intrinsic::Texture_Load_3:
+            ConvertIntrinsicCallTextureLoad(ast);
+            break;
         case Intrinsic::Image_Store:
             ConvertIntrinsicCallImageStore(ast);
             break;
@@ -969,6 +974,20 @@ void GLSLConverter::ConvertIntrinsicCallTextureSampleLevel(CallExpr* ast)
         /* Ensure argument: int[1,2,3] Offset */
         if (args.size() >= 4)
             exprConverter_.ConvertExprIfCastRequired(args[3], VectorDataType(DataType::Int, textureDim), true);
+    }
+}
+
+void GLSLConverter::ConvertIntrinsicCallTextureLoad(CallExpr* ast)
+{
+    /* Determine vector size for texture intrinsic */
+    if (auto textureDim = GetTextureDimFromIntrinsicCall(ast))
+    {
+        /* Convert arguments */
+        auto& args = ast->arguments;
+
+        /* Ensure argument: int[1,2,3] Offset */
+        if (args.size() >= 2)
+            exprConverter_.ConvertExprIfCastRequired(args[1], VectorDataType(DataType::Int, textureDim), true);
     }
 }
 

--- a/src/Compiler/Backend/GLSL/GLSLConverter.h
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.h
@@ -103,6 +103,7 @@ class GLSLConverter : public Converter
         void ConvertIntrinsicCallTexLod(CallExpr* ast);
         void ConvertIntrinsicCallTextureSample(CallExpr* ast);
         void ConvertIntrinsicCallTextureSampleLevel(CallExpr* ast);
+        void ConvertIntrinsicCallTextureLoad(CallExpr* ast);
         void ConvertIntrinsicCallImageAtomic(CallExpr* ast);
         void ConvertIntrinsicCallImageStore(CallExpr* ast);
         void ConvertIntrinsicCallGather(CallExpr* ast);

--- a/test/SamplerBuffer1.hlsl
+++ b/test/SamplerBuffer1.hlsl
@@ -1,0 +1,15 @@
+Buffer<float4> boneMatrices[2][3];
+
+float3x4 getBoneMatrix(uint idx)
+{
+    float4 row0 = boneMatrices[1][2][idx * 3 + 0];
+    float4 row1 = boneMatrices[1][2][idx * 3 + 1];
+    float4 row2 = boneMatrices[1][2][idx * 3 + 2];
+    
+    return float3x4(row0, row1, row2);
+}
+
+float4 main() : SV_Position
+{
+	return mul(getBoneMatrix(0), float4(1, 2, 3, 4));
+}

--- a/test/presetting.txt
+++ b/test/presetting.txt
@@ -166,3 +166,6 @@
 
 [GatherTest2 VS]
 -T vert -E main -o output/* GatherTest2.hlsl
+
+[SamplerBuffer1 VS]
+-T vert -E main -o output/* SamplerBuffer1.hlsl


### PR DESCRIPTION
I fixed a couple of issues with my array access -> `texelFetch` conversion for buffers:
 - The case when buffers are part of an array is now handled
 - The generated intrinsic is now similar to what HLSL parser would generate, so it can be treated the same as non-generated `texelFetch`es

I have also added a cast for the `texelFetch` location parameter in the `GLSLConverter`. At one point it might be nice to have a list of all intrinsics with all their overloads, and handle all casts automatically? Or is this already somewhere and I'm missing it?

-----
P.S.
I had to add a `shared_ptr` alternative to `const TypeDenoter& GetAliased()` because the non-ptr version wasn't letting me retrieve sub-type-denoters because of the `const`ness.