### PR TITLE
Always use minimal dimension for vector-vector common type derivation

### DIFF
--- a/src/Compiler/AST/TypeDenoter.cpp
+++ b/src/Compiler/AST/TypeDenoter.cpp
@@ -215,7 +215,7 @@ TypeDenoterPtr TypeDenoter::FindCommonTypeDenoter(const TypeDenoterPtr& lhsTypeD
 
     /* Vector and Vector */
     if (lhsTypeDen->IsVector() && rhsTypeDen->IsVector())
-        return FindCommonTypeDenoterVectorAndVector(lhsTypeDen->As<BaseTypeDenoter>(), rhsTypeDen->As<BaseTypeDenoter>(), useMinDimension);
+        return FindCommonTypeDenoterVectorAndVector(lhsTypeDen->As<BaseTypeDenoter>(), rhsTypeDen->As<BaseTypeDenoter>(), true);
 
     /* Default type */
     return FindCommonTypeDenoterAnyAndAny(lhsTypeDen.get(), rhsTypeDen.get());


### PR DESCRIPTION
I've experienced a cast error reported by GLSL compiler. Code similar to this:
`float3 normal = normalize(float4(1, 1, 1, 1) - float3(1, 1, 1));`

Gets converted into:
`vec3 normal = vec3(vec4(1, 1, 1, 1) - vec4(vec3(1, 1, 1))));`

But it seems vectors cannot be cast to a higher dimension, i.e. `vec4(vec3(...))` is invalid GLSL. This means when a common type denoter it looked up, for vectors it must always be the lower dimension. I'm not sure if my change breaks some other code that might have been relying on opposite behavior.

I don't think this is an issue for matrices, as the spec seems to imply that unpopulated matrix entries will be equivalent to identity matrix (section 5.4.2 of 4.5 spec).