### PR TITLE
Various fixes relating to auto-generated 'image*' and 'texelFetch' intrinsics

### DIFF
--- a/src/Compiler/AST/Visitor/ExprConverter.cpp
+++ b/src/Compiler/AST/Visitor/ExprConverter.cpp
@@ -55,6 +55,60 @@ void ExprConverter::ConvertExprIntoBracket(ExprPtr& expr)
     expr = ASTFactory::MakeBracketExpr(expr);
 }
 
+int ExprConverter::GetTextureDimFromExpr(Expr* expr, const AST* ast)
+{
+    if (expr)
+    {
+        const auto& typeDen = expr->GetTypeDenoter()->GetAliased();
+        if (auto bufferTypeDen = typeDen.As<BufferTypeDenoter>())
+        {
+            /* Determine vector size for texture intrinsic parameters by texture buffer type */
+            switch (bufferTypeDen->bufferType)
+            {
+            case BufferType::Buffer:
+            case BufferType::RWBuffer:
+            case BufferType::Texture1D:
+            case BufferType::RWTexture1D:
+                return 1;
+            case BufferType::Texture1DArray:
+            case BufferType::RWTexture1DArray:
+            case BufferType::Texture2D:
+            case BufferType::RWTexture2D:
+            case BufferType::Texture2DMS:
+                return 2;
+            case BufferType::Texture2DArray:
+            case BufferType::RWTexture2DArray:
+            case BufferType::Texture2DMSArray:
+            case BufferType::Texture3D:
+            case BufferType::RWTexture3D:
+            case BufferType::TextureCube:
+                return 3;
+            case BufferType::TextureCubeArray:
+                return 4;
+            default:
+                break;
+            }
+        }
+        else if (auto samplerTypeDen = typeDen.As<SamplerTypeDenoter>())
+        {
+            /* Determine vector size for texture intrinsic parameters by sampler type */
+            switch (samplerTypeDen->samplerType)
+            {
+            case SamplerType::Sampler1D:
+                return 1;
+            case SamplerType::Sampler2D:
+                return 2;
+            case SamplerType::Sampler3D:
+            case SamplerType::SamplerCube:
+                return 3;
+            default:
+                break;
+            }
+        }
+        RuntimeErr(R_FailedToGetTextureDim, ast);
+    }
+    RuntimeErr(R_FailedToGetTextureDim, ast);
+}
 
 /*
  * ======= Private: =======
@@ -268,15 +322,22 @@ results in two function calls! Thus the index expression must be moved into a se
 void ExprConverter::ConvertExprImageAccessArray(ExprPtr& expr, ArrayExpr* arrayExpr, AssignExpr* assignExpr)
 {
     /* Fetch buffer type denoter from l-value prefix expression */
-    const auto& prefixTypeDen = arrayExpr->prefixExpr->GetTypeDenoter()->GetAliased();
+    auto prefixTypeDen = arrayExpr->prefixExpr->GetTypeDenoter()->GetSub();
 
-    if (auto bufferTypeDen = prefixTypeDen.As<BufferTypeDenoter>())
+    size_t numDims = 0;
+    if (auto arrayTypeDenoter = prefixTypeDen->As<ArrayTypeDenoter>())
+    {
+        numDims = arrayTypeDenoter->arrayDims.size();
+        prefixTypeDen = arrayTypeDenoter->subTypeDenoter;
+    }
+
+    if (auto bufferTypeDen = prefixTypeDen->As<BufferTypeDenoter>())
     {
         if (auto bufferDecl = bufferTypeDen->bufferDeclRef)
         {
             /* Is the buffer declaration a read/write texture? */
             const auto bufferType = bufferDecl->GetBufferType();
-            if (IsRWTextureBufferType(bufferType))
+            if (IsRWTextureBufferType(bufferType) && numDims < arrayExpr->NumIndices())
             {
                 /* Get buffer type denoter from array indices of array access plus identifier */
                 //TODO: not sure if the buffer type must be derived with 'GetSub(arrayExpr)' again here???
@@ -285,57 +346,75 @@ void ExprConverter::ConvertExprImageAccessArray(ExprPtr& expr, ArrayExpr* arrayE
                 #endif
                 if (auto genericBaseTypeDen = bufferTypeDen->genericTypeDenoter->As<BaseTypeDenoter>())
                 {
+                    arrayExpr->prefixExpr->flags << Expr::wasConverted;
+
                     /* Create a type denoter for the return value */
                     auto callTypeDen = MakeBufferAccessCallTypeDenoter(genericBaseTypeDen->dataType);
 
-                    if (!arrayExpr->arrayIndices.empty())
+                    /* Make first argument expression */
+                    ExprPtr arg0Expr;
+                    if (numDims > 0)
                     {
-                        /* Make first argument expression */
-                        auto arg0Expr = arrayExpr->prefixExpr;
-                        arg0Expr->flags << Expr::wasConverted;
+                        std::vector<ExprPtr> arrayIndices;
+                        for (size_t i = 0; i < numDims; i++)
+                            arrayIndices.push_back(arrayExpr->arrayIndices[i]);
 
-                        /* Get second argument expression (last array index) */
-                        auto arg1Expr = arrayExpr->arrayIndices.back();
+                        arg0Expr = ASTFactory::MakeArrayExpr(arrayExpr->prefixExpr, std::move(arrayIndices));
+                    }
+                    else
+                        arg0Expr = arrayExpr->prefixExpr;
 
-                        if (assignExpr)
+                    /* Get second argument expression (last array index) */
+                    auto arg1Expr = arrayExpr->arrayIndices.back();
+
+                    /* Cast to valid dimension */
+                    auto textureDim = GetTextureDimFromExpr(arg0Expr.get(), expr.get());
+                    ConvertExprIfCastRequired(arg1Expr, VectorDataType(DataType::Int, textureDim), true);
+
+                    if (assignExpr)
+                    {
+                        /* Get third argument expression (store value) */
+                        ExprPtr arg2Expr;
+
+                        if (assignExpr->op == AssignOp::Set)
                         {
-                            /* Get third argument expression (store value) */
-                            ExprPtr arg2Expr;
-
-                            if (assignExpr->op == AssignOp::Set)
-                            {
-                                /* Take r-value expression for standard assignemnt */
-                                arg2Expr = assignExpr->rvalueExpr;
-                            }
-                            else
-                            {
-                                /* Make compound assignment with an image-load instruction first */
-                                auto lhsExpr = ASTFactory::MakeIntrinsicCallExpr(
-                                    Intrinsic::Image_Load, "imageLoad", callTypeDen, { arg0Expr, arg1Expr }
-                                );
-
-                                auto rhsExpr = assignExpr->rvalueExpr;
-
-                                const auto binaryOp = AssignOpToBinaryOp(assignExpr->op);
-
-                                arg2Expr = ASTFactory::MakeBinaryExpr(lhsExpr, binaryOp, rhsExpr);
-                            }
-
-                            /* Convert expression to intrinsic call */
-                            expr = ASTFactory::MakeIntrinsicCallExpr(
-                                Intrinsic::Image_Store, "imageStore", nullptr, { arg0Expr, arg1Expr, arg2Expr }
-                            );
+                            /* Take r-value expression for standard assignemnt */
+                            arg2Expr = assignExpr->rvalueExpr;
                         }
                         else
                         {
-                            /* Convert expression to intrinsic call */
-                            expr = ASTFactory::MakeIntrinsicCallExpr(
+                            /* Make compound assignment with an image-load instruction first */
+                            auto lhsExpr = ASTFactory::MakeIntrinsicCallExpr(
                                 Intrinsic::Image_Load, "imageLoad", callTypeDen, { arg0Expr, arg1Expr }
                             );
+
+                            auto rhsExpr = assignExpr->rvalueExpr;
+
+                            const auto binaryOp = AssignOpToBinaryOp(assignExpr->op);
+
+                            arg2Expr = ASTFactory::MakeBinaryExpr(lhsExpr, binaryOp, rhsExpr);
                         }
+
+                        /* Cast to valid 4D vector type */
+                        if (IsIntType(genericBaseTypeDen->dataType))
+                            ConvertExprIfCastRequired(arg2Expr, DataType::Int4, true);
+                        else if (IsUIntType(genericBaseTypeDen->dataType))
+                            ConvertExprIfCastRequired(arg2Expr, DataType::UInt4, true);
+                        else
+                            ConvertExprIfCastRequired(arg2Expr, DataType::Float4, true);
+
+                        /* Convert expression to intrinsic call */
+                        expr = ASTFactory::MakeIntrinsicCallExpr(
+                            Intrinsic::Image_Store, "imageStore", nullptr, { arg0Expr, arg1Expr, arg2Expr }
+                        );
                     }
                     else
-                        RuntimeErr(R_MissingArrayIndexInOp(bufferTypeDen->ToString()), arrayExpr);
+                    {
+                        /* Convert expression to intrinsic call */
+                        expr = ASTFactory::MakeIntrinsicCallExpr(
+                            Intrinsic::Image_Load, "imageLoad", callTypeDen, { arg0Expr, arg1Expr }
+                        );
+                    }
                 }
             }
         }
@@ -398,10 +477,10 @@ void ExprConverter::ConvertExprSamplerBufferAccessArray(ExprPtr& expr, ArrayExpr
                         for (std::size_t i = 0; i < numDims; i++)
                             arrayIndices.push_back(arrayExpr->arrayIndices[i]);
 
-                        callExpr->prefixExpr = ASTFactory::MakeArrayExpr(ASTFactory::MakeObjectExpr(bufferDecl), std::move(arrayIndices));
+                        callExpr->prefixExpr = ASTFactory::MakeArrayExpr(arrayExpr->prefixExpr, std::move(arrayIndices));
                     }
                     else
-                        callExpr->prefixExpr = ASTFactory::MakeObjectExpr(bufferDecl);
+                        callExpr->prefixExpr = arrayExpr->prefixExpr;
 
                     expr = callExpr;
                 }

--- a/src/Compiler/AST/Visitor/ExprConverter.h
+++ b/src/Compiler/AST/Visitor/ExprConverter.h
@@ -62,6 +62,7 @@ class ExprConverter : public Visitor
         void ConvertExprIfCastRequired(ExprPtr& expr, const DataType targetType, bool matchTypeSize = true);
         void ConvertExprIfCastRequired(ExprPtr& expr, const TypeDenoter& targetTypeDen, bool matchTypeSize = true);
 
+        static int GetTextureDimFromExpr(Expr* expr, const AST* ast = nullptr);
     private:
         
         /* === Functions === */

--- a/src/Compiler/Backend/GLSL/GLSLConverter.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.cpp
@@ -821,9 +821,6 @@ void GLSLConverter::ConvertIntrinsicCall(CallExpr* ast)
         case Intrinsic::Texture_Load_3:
             ConvertIntrinsicCallTextureLoad(ast);
             break;
-        case Intrinsic::Image_Store:
-            ConvertIntrinsicCallImageStore(ast);
-            break;
         default:
             break;
     }
@@ -848,60 +845,11 @@ void GLSLConverter::ConvertIntrinsicCallSaturate(CallExpr* ast)
         RuntimeErr(R_InvalidIntrinsicArgCount(ast->ident, 1, ast->arguments.size()), ast);
 }
 
-static int GetTextureDimFromExpr(Expr* expr, const AST* ast = nullptr)
-{
-    if (expr)
-    {
-        const auto& typeDen = expr->GetTypeDenoter()->GetAliased();
-        if (auto bufferTypeDen = typeDen.As<BufferTypeDenoter>())
-        {
-            /* Determine vector size for texture intrinsic parameters by texture buffer type */
-            switch (bufferTypeDen->bufferType)
-            {
-                case BufferType::Buffer:
-                case BufferType::Texture1D:
-                    return 1;
-                case BufferType::Texture1DArray:
-                case BufferType::Texture2D:
-                case BufferType::Texture2DMS:
-                    return 2;
-                case BufferType::Texture2DArray:
-                case BufferType::Texture2DMSArray:
-                case BufferType::Texture3D:
-                case BufferType::TextureCube:
-                    return 3;
-                case BufferType::TextureCubeArray:
-                    return 4;
-                default:
-                    break;
-            }
-        }
-        else if (auto samplerTypeDen = typeDen.As<SamplerTypeDenoter>())
-        {
-            /* Determine vector size for texture intrinsic parameters by sampler type */
-            switch (samplerTypeDen->samplerType)
-            {
-                case SamplerType::Sampler1D:
-                    return 1;
-                case SamplerType::Sampler2D:
-                    return 2;
-                case SamplerType::Sampler3D:
-                case SamplerType::SamplerCube:
-                    return 3;
-                default:
-                    break;
-            }
-        }
-        RuntimeErr(R_FailedToGetTextureDim, ast);
-    }
-    RuntimeErr(R_FailedToGetTextureDim, ast);
-}
-
 static int GetTextureDimFromIntrinsicCall(CallExpr* ast)
 {
     /* Get buffer object from sample intrinsic call */
     if (ast->prefixExpr)
-        return GetTextureDimFromExpr(ast->prefixExpr.get(), ast);
+        return ExprConverter::GetTextureDimFromExpr(ast->prefixExpr.get(), ast);
     else
         RuntimeErr(R_FailedToGetTextureDim, ast);
 }
@@ -914,7 +862,7 @@ void GLSLConverter::ConvertIntrinsicCallTexLod(CallExpr* ast)
         auto& args = ast->arguments;
 
         /* Determine vector size for texture intrinsic */
-        if (auto textureDim = GetTextureDimFromExpr(args[0].get()))
+        if (auto textureDim = ExprConverter::GetTextureDimFromExpr(args[0].get()))
         {
             /* Convert arguments */
             exprConverter_.ConvertExprIfCastRequired(args[1], DataType::Float4, true);
@@ -1031,52 +979,6 @@ void GLSLConverter::ConvertIntrinsicCallImageAtomic(CallExpr* ast)
                 }
             }
         }
-    }
-}
-
-void GLSLConverter::ConvertIntrinsicCallImageStore(CallExpr* ast)
-{
-    /* Cast input value argument to 4 component vector */
-    auto& args = ast->arguments;
-
-    if (args.size() >= 3)
-    {
-        /* Determine base data type form generic buffer type denoter */
-        DataType dataType = DataType::Float;
-
-        auto nonBracketExpr = args.front()->FindFirstNotOf(AST::Types::BracketExpr);
-
-        if (auto arg0ArrayExpr = nonBracketExpr->As<ArrayExpr>())
-        {
-            const auto& typeDen = arg0ArrayExpr->prefixExpr->GetTypeDenoter()->GetAliased();
-            if (auto bufferTypeDen = typeDen.As<BufferTypeDenoter>())
-            {
-                if (bufferTypeDen->genericTypeDenoter != nullptr)
-                {
-                    if (auto genericBaseTypeDen = bufferTypeDen->genericTypeDenoter->As<BaseTypeDenoter>())
-                        dataType = genericBaseTypeDen->dataType;
-                }
-            }
-        }
-        else
-        {
-            const auto& typeDen = nonBracketExpr->GetTypeDenoter()->GetAliased();
-            if (auto bufferTypeDen = typeDen.As<BufferTypeDenoter>())
-            {
-                if (bufferTypeDen->genericTypeDenoter != nullptr)
-                {
-                    if (auto genericBaseTypeDen = bufferTypeDen->genericTypeDenoter->As<BaseTypeDenoter>())
-                        dataType = genericBaseTypeDen->dataType;
-                }
-            }
-        }
-
-        if (IsIntType(dataType))
-            exprConverter_.ConvertExprIfCastRequired(args[2], DataType::Int4, true);
-        else if (IsUIntType(dataType))
-            exprConverter_.ConvertExprIfCastRequired(args[2], DataType::UInt4, true);
-        else
-            exprConverter_.ConvertExprIfCastRequired(args[2], DataType::Float4, true);
     }
 }
 

--- a/src/Compiler/Backend/GLSL/GLSLConverter.h
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.h
@@ -105,7 +105,6 @@ class GLSLConverter : public Converter
         void ConvertIntrinsicCallTextureSampleLevel(CallExpr* ast);
         void ConvertIntrinsicCallTextureLoad(CallExpr* ast);
         void ConvertIntrinsicCallImageAtomic(CallExpr* ast);
-        void ConvertIntrinsicCallImageStore(CallExpr* ast);
         void ConvertIntrinsicCallGather(CallExpr* ast);
 
         void ConvertFunctionCall(CallExpr* ast);

--- a/test/RWTextureTest1.hlsl
+++ b/test/RWTextureTest1.hlsl
@@ -2,10 +2,10 @@
 // RWTexture Test 1
 // 13/03/2017
 
-RWTexture2D<int> tex[2];
+RWTexture2D<int> tex[2][2];
 
 void main()
 {
-    float4 a = (tex[0])[int2(1, 2)]; // must be "imageLoad(tex[0], ivec2(1, 2))" in GLSL
-    float4 b =  tex[0] [int2(3, 4)]; // must be "imageLoad(tex[0], ivec2(1, 2))" in GLSL
+    float4 a = (tex[0])[1][int2(1, 2)]; // must be "imageLoad(tex[0], ivec2(1, 2))" in GLSL
+    float4 b =  tex[0][1] [int2(3, 4)]; // must be "imageLoad(tex[0], ivec2(1, 2))" in GLSL
 }

--- a/test/SamplerBuffer1.hlsl
+++ b/test/SamplerBuffer1.hlsl
@@ -2,7 +2,7 @@ Buffer<float4> boneMatrices[2][3];
 
 float3x4 getBoneMatrix(uint idx)
 {
-    float4 row0 = boneMatrices[1][2][idx * 3 + 0];
+    float4 row0 = (boneMatrices[1])[2][idx * 3 + 0];
     float4 row1 = boneMatrices[1][2][idx * 3 + 1];
     float4 row2 = boneMatrices[1][2][idx * 3 + 2];
     


### PR DESCRIPTION
I've modified generation for `imageLoad`, `imageStore`, and `texelFetch` intrinsics, so they now properly handle arrays and brackets. This fixes incorrect translation of `RWTextureTest1` you previously mentioned.

I've also moved the casts for the generated `imageLoad` / `imageStore` calls into `ExprConverter`, where they're generated. You mentioned previously they don't fit in `GLSLConverter`, and now that I understand the code a bit better, I agree.

And I added an extra cast for the location parameter of `imageLoad` and `imageStore`.