### PR TITLE
Added wrappers for memory barriers

### DIFF
--- a/src/Compiler/Backend/GLSL/GLSLGenerator.h
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.h
@@ -259,6 +259,7 @@ class GLSLGenerator : public Generator
         void WriteWrapperIntrinsicsClip(const IntrinsicUsage& usage);
         void WriteWrapperIntrinsicsLit(const IntrinsicUsage& usage);
         void WriteWrapperIntrinsicsSinCos(const IntrinsicUsage& usage);
+        void WriteWrapperIntrinsicMemoryBarrier(Intrinsic barrierIntrinsic, bool groupSync, const IntrinsicUsage& usage);
 
         /* ----- Structure ----- */
 

--- a/src/Compiler/Backend/GLSL/GLSLIntrinsics.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLIntrinsics.cpp
@@ -24,7 +24,7 @@ static std::map<Intrinsic, std::string> GenerateIntrinsicMap()
         { T::ACos,                             "acos"                  },
         { T::All,                              "all"                   },
         { T::AllMemoryBarrier,                 "memoryBarrier"         },
-        { T::AllMemoryBarrierWithGroupSync,    "barrier"               }, //???
+      //{ T::AllMemoryBarrierWithGroupSync,    ""                      }, //???
         { T::Any,                              "any"                   },
         { T::AsDouble,                         "uint64BitsToDouble"    },
         { T::AsFloat,                          "uintBitsToFloat"       },
@@ -51,8 +51,8 @@ static std::map<Intrinsic, std::string> GenerateIntrinsicMap()
         { T::DDYFine,                          "dFdyFine"              },
         { T::Degrees,                          "degrees"               },
         { T::Determinant,                      "determinant"           },
-        { T::DeviceMemoryBarrier,              "barrier"               }, // ??? memoryBarrier, memoryBarrierImage, memoryBarrierImage, and barrier
-        { T::DeviceMemoryBarrierWithGroupSync, "barrier"               }, // ??? memoryBarrier, memoryBarrierImage, memoryBarrierImage
+      //{ T::DeviceMemoryBarrier,              ""                      }, // ??? memoryBarrier, memoryBarrierImage, memoryBarrierImage, and barrier
+      //{ T::DeviceMemoryBarrierWithGroupSync, ""                      }, // ??? memoryBarrier, memoryBarrierImage, memoryBarrierImage
         { T::Distance,                         "distance"              },
         { T::Dot,                              "dot"                   },
       //{ T::Dst,                              ""                      },
@@ -79,7 +79,7 @@ static std::map<Intrinsic, std::string> GenerateIntrinsicMap()
         { T::GreaterThan,                      "greaterThan"           }, // GLSL only
         { T::GreaterThanEqual,                 "greaterThanEqual"      }, // GLSL only
         { T::GroupMemoryBarrier,               "groupMemoryBarrier"    },
-        { T::GroupMemoryBarrierWithGroupSync,  "barrier"               }, // ??? groupMemoryBarrier and barrier
+      //{ T::GroupMemoryBarrierWithGroupSync,  ""                      }, // ??? groupMemoryBarrier and barrier
         { T::InterlockedAdd,                   "atomicAdd"             },
         { T::InterlockedAnd,                   "atomicAnd"             },
         { T::InterlockedCompareExchange,       "atomicCompSwap"        },

--- a/test/MemoryBarrierTest1.hlsl
+++ b/test/MemoryBarrierTest1.hlsl
@@ -1,0 +1,8 @@
+[numthreads(8, 8, 1)]
+void main()
+{
+    GroupMemoryBarrier();
+    GroupMemoryBarrierWithGroupSync();
+    DeviceMemoryBarrier();
+    DeviceMemoryBarrierWithGroupSync();
+} 

--- a/test/presetting.txt
+++ b/test/presetting.txt
@@ -169,3 +169,6 @@
 
 [SamplerBuffer1 VS]
 -T vert -E main -o output/* SamplerBuffer1.hlsl
+
+[MemoryBarrierTest1 VS]
+-T comp -E main -o output/* MemoryBarrierTest1.hlsl


### PR DESCRIPTION
I've added code for generating wrappers for HLSL memory barriers that don't directly map to a single GLSL intrinsic (e.g. `GroupMemoryBarrierWithGroupSync`).

P.S. I apologize for so many PRs, I know reviewing (and correcting) them takes effort. I'm trying to get some more complex Banshee shaders to compile. I'll probably continue at this pace for at least a few more days.