### PR TITLE
Fixing code generation for the 'texelFetch' intrinsic

### DIFF
--- a/src/Compiler/Frontend/HLSL/HLSLAnalyzer.cpp
+++ b/src/Compiler/Frontend/HLSL/HLSLAnalyzer.cpp
@@ -1047,6 +1047,26 @@ void HLSLAnalyzer::AnalyzeCallExprIntrinsicFromBufferType(const CallExpr* callEx
             break;
         }
     }
+
+    /* Ensure load intrinsics are only used on supported types */
+    if(intrinsic == Intrinsic::Texture_Load_1)
+    {
+        /* Sample index is required for MS textures */
+        if (bufferType == BufferType::Texture2DMS || bufferType == BufferType::Texture2DMSArray)
+            Error(R_InvalidClassIntrinsicForType(ident, BufferTypeToString(bufferType)), callExpr);
+    }
+    else if(intrinsic == Intrinsic::Texture_Load_2)
+    {
+        /* Buffer loads only support the one parameter version */
+        if (bufferType == BufferType::Buffer)
+            Error(R_InvalidClassIntrinsicForType(ident, BufferTypeToString(bufferType)), callExpr);
+    }
+    else if(intrinsic == Intrinsic::Texture_Load_3)
+    {
+        /* Sample index + offset overload is only supported for MS textures */
+        if(bufferType != BufferType::Texture2DMS && bufferType != BufferType::Texture2DMSArray)
+            Error(R_InvalidClassIntrinsicForType(ident, BufferTypeToString(bufferType)), callExpr);
+    }
 }
 
 void HLSLAnalyzer::AnalyzeIntrinsicWrapperInlining(CallExpr* callExpr)

--- a/src/Compiler/Report/ReportIdentsEN.h
+++ b/src/Compiler/Report/ReportIdentsEN.h
@@ -290,6 +290,7 @@ DECL_REPORT( MissingScopedStmntRef,             "missing reference to scoped sta
 
 DECL_REPORT( MissingSelfParamForMemberFunc,     "missing 'self'-parameter for member function[ '{0}']"                                                          );
 DECL_REPORT( FailedToGetTextureDim,             "failed to determine dimension of texture object[ '{0}']"                                                       );
+DECL_REPORT( FailedToMapClassIntrinsicOverload, "failed to map overload of class intrinsic '{0}' for type '{1}'"                                                );
 
 /* ----- GLSLExtensionAgent ----- */
 

--- a/test/TexelFetchTest1.hlsl
+++ b/test/TexelFetchTest1.hlsl
@@ -1,0 +1,13 @@
+Buffer<float4> buf;
+Texture2D tex;
+Texture2DMS tex2;
+
+float4 main() : SV_Position
+{
+	float4 val = buf[0u];
+	float4 val2 = buf.Load(0u);
+	float4 val3 = tex.Load(uint3(0, 0, 0));
+	float4 val4 = tex2.Load(uint2(0, 0), 0);
+	
+	return val + val2 + val3 + val4;
+}

--- a/test/presetting.txt
+++ b/test/presetting.txt
@@ -169,3 +169,6 @@
 
 [SamplerBuffer1 VS]
 -T vert -E main -o output/* SamplerBuffer1.hlsl
+
+[TexelFetchTest1 VS]
+-T vert -E main -o output/* TexelFetchTest1.hlsl


### PR DESCRIPTION
Previously HLSL `obj.Load()` intrinsic parameters were being mapped directly as-is to `texelFetch` intrisic, which only resulted in valid code when the single-parameter version was used on buffers. 

When used on textures HLSL expects the `Location` parameter to contain the mip level as well as the texture coordinates, while GLSL expects them as separate arguments.

This patch properly converts the arguments, as well as handles any casting. I also added some error checking in the analyzer and converter.