### PR TITLE
Added support for combined samplers when generating VKSL

### DIFF
--- a/inc/Xsc/Xsc.h
+++ b/inc/Xsc/Xsc.h
@@ -163,6 +163,9 @@ struct Options
     //! If true, generated GLSL code will support the 'ARB_separate_shader_objects' extension. By default false.
     bool    separateShaders         = false;
 
+    //! If true, generated GLSL code will contain separate sampler and texture objects when supported. By default true.
+    bool    separateSamplers        = true;
+
     //! If true, code obfuscation is performed. By default false.
     bool    obfuscate               = false;
 

--- a/src/Compiler/Backend/GLSL/GLSLConverter.h
+++ b/src/Compiler/Backend/GLSL/GLSLConverter.h
@@ -43,6 +43,9 @@ class GLSLConverter : public Converter
         // Returns true if the 'GL_ARB_shading_language_420pack' is explicitly available.
         bool HasShadingLanguage420Pack() const;
 
+        // Returns true if separate objects for samplers & textures should be used.
+        bool UseSeparateSamplers() const;
+
         /* ----- Visitor implementation ----- */
 
         DECL_VISIT_PROC( Program           );
@@ -160,6 +163,7 @@ class GLSLConverter : public Converter
         Options                     options_;
         bool                        autoBinding_        = false;
         int                         autoBindingSlot_    = 0;
+        bool                        separateSamplers_   = true;
 
         /*
         List of all variables with reserved identifiers that come from a structure that must be resolved.

--- a/src/Compiler/Backend/GLSL/GLSLGenerator.h
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.h
@@ -66,6 +66,9 @@ class GLSLGenerator : public Generator
         // Returns true if the output shader language is VKSL (for Vulkan/SPIR-V).
         bool IsVKSL() const;
 
+        // Returns true if separate objects for samplers & textures should be used.
+        bool UseSeparateSamplers() const;
+
         // Returns the GLSL keyword for the specified buffer type or reports and error.
         const std::string* BufferTypeToKeyword(const BufferType bufferType, const AST* ast = nullptr);
 
@@ -307,6 +310,7 @@ class GLSLGenerator : public Generator
         bool                                    compactWrappers_        = false;
         bool                                    alwaysBracedScopes_     = false;
         bool                                    separateShaders_        = false;
+        bool                                    separateSamplers_       = true;
 
         bool                                    isInsideInterfaceBlock_ = false;
 };

--- a/src/Compiler/Backend/GLSL/GLSLKeywords.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLKeywords.cpp
@@ -294,10 +294,18 @@ static std::map<BufferType, std::string> GenerateBufferTypeMapVKSL()
     };
 }
 
-const std::string* BufferTypeToGLSLKeyword(const BufferType t, bool useVulkanGLSL)
+const std::string* BufferTypeToGLSLKeyword(const BufferType t, bool useVulkanGLSL, bool separateSamplers)
 {
     static const auto typeMapGLSL = GenerateBufferTypeMap();
     static const auto typeMapVKSL = GenerateBufferTypeMapVKSL();
+
+    if (useVulkanGLSL && !separateSamplers)
+    {
+        auto samplerType = TextureTypeToSamplerType(t);
+        if(samplerType != SamplerType::Undefined)
+            useVulkanGLSL = false;
+    }
+
     return MapTypeToKeyword((useVulkanGLSL ? typeMapVKSL : typeMapGLSL), t);
 }
 

--- a/src/Compiler/Backend/GLSL/GLSLKeywords.h
+++ b/src/Compiler/Backend/GLSL/GLSLKeywords.h
@@ -36,7 +36,7 @@ const std::string* StorageClassToGLSLKeyword(const StorageClass t);
 const std::string* InterpModifierToGLSLKeyword(const InterpModifier t);
 
 // Returns the GLSL keyword for the specified buffer type or null on failure.
-const std::string* BufferTypeToGLSLKeyword(const BufferType t, bool useVulkanGLSL = false);
+const std::string* BufferTypeToGLSLKeyword(const BufferType t, bool useVulkanGLSL = false, bool separateSamplers = true);
 
 // Returns the GLSL keyword for the specified sampler type or null on failure.
 const std::string* SamplerTypeToGLSLKeyword(const SamplerType t);

--- a/src/Debugger/DebuggerView.cpp
+++ b/src/Debugger/DebuggerView.cpp
@@ -215,6 +215,7 @@ void DebuggerView::CreateLayoutPropertyGridOptions(wxPropertyGrid& pg)
     pg.Append(new wxBoolProperty("Unroll Array Initializers", "unrollInitializers"));
     pg.Append(new wxBoolProperty("Row-Major Alignment", "rowMajor"));
     pg.Append(new wxBoolProperty("Separate Shaders", "separateShaders"));
+    pg.Append(new wxBoolProperty("Separate Samplers", "separateSamplers", true));
     pg.Append(new wxBoolProperty("Obfuscate", "obfuscate"));
     pg.Append(new wxBoolProperty("Show AST", "showAST"));
 }
@@ -442,6 +443,8 @@ void DebuggerView::OnPropertyGridChange(wxPropertyGridEvent& event)
         shaderOutput_.options.autoBindingStartSlot = ValueInt();
     else if (name == "separateShaders")
         shaderOutput_.options.separateShaders = ValueBool();
+    else if (name == "separateSamplers")
+        shaderOutput_.options.separateSamplers = ValueBool();
 
     /* --- Formatting --- */
     else if (name == "blanks")

--- a/src/Shell/Command.cpp
+++ b/src/Shell/Command.cpp
@@ -1288,6 +1288,29 @@ void SeparateShadersCommand::Run(CommandLine& cmdLine, ShellState& state)
     state.outputDesc.options.separateShaders = cmdLine.AcceptBoolean(true);
 }
 
+/*
+ * SeparateSamplersCommand class
+ */
+
+std::vector<Command::Identifier> SeparateSamplersCommand::Idents() const
+{
+    return { { "--separate-samplers" } };
+}
+
+HelpDescriptor SeparateSamplersCommand::Help() const
+{
+    return
+    {
+        "--separate-samplers [" + CommandLine::GetBooleanOption() + "]",
+        "Enables/disables generation of separate sampler state objects, when supported; default=" + CommandLine::GetBooleanTrue()
+    };
+}
+
+void SeparateSamplersCommand::Run(CommandLine& cmdLine, ShellState& state)
+{
+    state.outputDesc.options.separateSamplers = cmdLine.AcceptBoolean(true);
+}
+
 
 
 } // /namespace Util

--- a/src/Shell/Command.h
+++ b/src/Shell/Command.h
@@ -105,6 +105,7 @@ DECL_SHELL_COMMAND( IndentCommand                );
 DECL_SHELL_COMMAND( PrefixCommand                );
 DECL_SHELL_COMMAND( NameManglingCommand          );
 DECL_SHELL_COMMAND( SeparateShadersCommand       );
+DECL_SHELL_COMMAND( SeparateSamplersCommand       );
 
 #undef DECL_SHELL_COMMAND
 

--- a/src/Shell/CommandFactory.cpp
+++ b/src/Shell/CommandFactory.cpp
@@ -87,7 +87,8 @@ CommandFactory::CommandFactory()
         IndentCommand,
         PrefixCommand,
         NameManglingCommand,
-        SeparateShadersCommand
+        SeparateShadersCommand,
+        SeparateSamplersCommand
     >();
 }
 


### PR DESCRIPTION
Vulkan supports both combined samplers (same as GLSL) and separate texture & sampler objects. XShaderCompiler defaults to separate samplers when generating VKSL. 

I've added a flag that allows the user to disable this functionality in order to support combined samplers on VKSL. The flag is `--separate-samplers` and by default it is on, meaning there is no change to VKSL code by default, unless user explicitly turns this behavior off.