### PR TITLE
Added support for the 'layout' attribute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(XSC_BUILD_WRAPPER_CSHARP "Build C# wrapper" OFF)
 
 option(XSC_ENABLE_EASTER_EGGS "Enables little easter eggs" OFF)
 option(XSC_ENABLE_POST_VALIDATION "Enables the post validation in presettings with 'glslangValidator'" OFF)
+option(XSC_ENABLE_LANGUAGE_EXT "Enables a few language extensions (e.g. 'space' attribute for stronger type system)" OFF)
 
 option(XSC_SHARED_LIB "Build XShaderCompiler as a shared library instead of a static library" OFF)
 
@@ -46,6 +47,9 @@ if(XSC_ENABLE_POST_VALIDATION)
 	add_definitions(-DXSC_ENABLE_POST_VALIDATION)
 endif()
 
+if(XSC_ENABLE_LANGUAGE_EXT)
+    add_definitions(-DXSC_ENABLE_LANGUAGE_EXT)
+endif()
 
 # === Global files ===
 

--- a/inc/Xsc/Xsc.h
+++ b/inc/Xsc/Xsc.h
@@ -96,6 +96,21 @@ struct Warnings
     };
 };
 
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+
+//! Language extensions.
+struct Extensions
+{
+    enum : unsigned int
+    {
+        LayoutAttribute         = (1 << 0), //!< Enables the 'layout' attribute.
+
+        All                     = (~0u)     //!< All extensions.
+    };
+};
+
+#endif
+
 //! Formatting descriptor structure for the output shader.
 struct Formatting
 {
@@ -260,6 +275,16 @@ struct ShaderInput
     \remarks If this is null, the default include handler will be used, which will include files with the STL input file streams.
     */
     IncludeHandler*                 includeHandler      = nullptr;
+
+    #ifdef XSC_ENABLE_LANGUAGE_EXT
+
+    /**
+    \brief Enabled language extensions. This can be a bitwise OR combination of the "Extensions" enumeration entries. By default 0.
+    \see Extensions
+    */
+    unsigned int                    extensions          = 0;
+
+    #endif
 };
 
 //! Vertex shader semantic (or rather attribute) layout structure.

--- a/inc/XscC/XscC.h
+++ b/inc/XscC/XscC.h
@@ -40,6 +40,18 @@ enum XscWarnings
     XscWarnAll                      = (~0u),    //!< All warnings.
 };
 
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+
+//! Language extensions.
+enum XscExtensions
+{
+    XscExtLayoutAttribute           = (1 << 0), //!< Enables the 'layout' attribute.
+
+    XscExtAll                       = (~0u)     //!< All extensions.
+};
+
+#endif
+
 //! Formatting descriptor structure for the output shader.
 struct XscFormatting
 {
@@ -195,12 +207,22 @@ struct XscShaderInput
 
     /**
     \brief Compiler warning flags. This can be a bitwise OR combination of the "XscWarnings" enumeration entries. By default 0.
-    \see Warnings
+    \see XscWarnings
     */
     unsigned int                    warnings;
 
     //! Include handler member which contains a function pointer to handle '#include'-directives.
     struct XscIncludeHandler        includeHandler;
+
+    #ifdef XSC_ENABLE_LANGUAGE_EXT
+
+    /**
+    \brief Enabled language extensions. This can be a bitwise OR combination of the "XscExtensions" enumeration entries. By default 0.
+    \see XscExtensions
+    */
+    unsigned int                    extensions;
+
+    #endif
 };
 
 //! Vertex shader semantic (or rather attribute) layout structure.

--- a/src/Compiler/AST/AST.h
+++ b/src/Compiler/AST/AST.h
@@ -566,7 +566,8 @@ struct BufferDecl : public Decl
 
     FLAG_ENUM
     {
-        FLAG( isUsedForCompare, 2 ), // This buffer is used in a texture compare operation.
+        FLAG( isUsedForCompare,     2 ), // This buffer is used in a texture compare operation.
+        FLAG( isUsedForImageRead,   3 )  // This is a buffer used in an image load or image atomic operation.
     };
 
     TypeDenoterPtr DeriveTypeDenoter(const TypeDenoter* expectedTypeDenoter) override;

--- a/src/Compiler/AST/ASTEnums.cpp
+++ b/src/Compiler/AST/ASTEnums.cpp
@@ -865,6 +865,21 @@ SamplerType SamplerTypeToShadowSamplerType(const SamplerType t)
 }
 
 
+/* ----- ImageLayoutFormat Enum ----- */
+
+DataType GetImageLayoutFormatBaseType(const ImageLayoutFormat format)
+{
+    if (format >= ImageLayoutFormat::F32X4 && format <= ImageLayoutFormat::SN8X1)
+        return DataType::Float;
+    else if (format >= ImageLayoutFormat::I32X4 && format <= ImageLayoutFormat::I8X1)
+        return DataType::Int;
+    else if (format >= ImageLayoutFormat::UI32X4 && format <= ImageLayoutFormat::UI8X1)
+        return DataType::UInt;
+
+    return DataType::Undefined;
+}
+
+
 /* ----- RegisterType Enum ----- */
 
 RegisterType CharToRegisterType(char c)

--- a/src/Compiler/AST/ASTEnums.h
+++ b/src/Compiler/AST/ASTEnums.h
@@ -493,6 +493,67 @@ SamplerType TextureTypeToSamplerType(const BufferType t);
 SamplerType SamplerTypeToShadowSamplerType(const SamplerType t);
 
 
+/* ----- ImageLayoutFormat Enum ----- */
+
+// Image layout format enumeration
+enum class ImageLayoutFormat
+{
+    Undefined,
+
+    /* --- Float formats --- */
+    F32X4,          // rgba32f
+    F32X2,          // rg32f
+    F32X1,          // r32f
+    F16X4,          // rgba16f
+    F16X2,          // rg16f
+    F16X1,          // r16f
+    F11R11G10B,     // r11f_g11f_b10f
+
+    /* --- Unsigned normalized formats --- */
+    UN32X4,         // rgba16
+    UN16X2,         // rg16
+    UN16X1,         // r16
+    UN10R10G10B2A,  // rgb10_a2
+    UN8X4,          // rgba8
+    UN8X2,          // rg8
+    UN8X1,          // r8
+
+    /* --- Signed normalized formats --- */
+    SN16X4,         // rgba16_snorm
+    SN16X2,         // rg16_snorm
+    SN16X1,         // r16_snorm
+    SN8X4,          // rgba8_snorm
+    SN8X2,          // rg8_snorm
+    SN8X1,          // r8_snorm
+    
+    /* --- Signed integer formats --- */
+    I32X4,          // rgba32i
+    I32X2,          // rg32i
+    I32X1,          // r32i
+    I16X4,          // rgba16i
+    I16X2,          // rg16i
+    I16X1,          // r16i
+    I8X4,           // rgba8i
+    I8X2,           // rg8i
+    I8X1,           // r8i
+    
+    /* --- Unsigned integer formats --- */
+    UI32X4,         // rgba32ui
+    UI32X2,         // rg32ui
+    UI32X1,         // r32ui
+    UI16X4,         // rgba16ui
+    UI16X2,         // rg16ui
+    UI16X1,         // r16ui
+    UI10R10G10B2A,  // rgb10_a2ui
+    UI8X4,          // rgba8ui
+    UI8X2,          // rg8ui
+    UI8X1,          // r8ui
+};
+
+// Returns the base type of a single component in the specified image layout format.
+DataType GetImageLayoutFormatBaseType(const ImageLayoutFormat format);
+
+
 /* ----- RegisterType Enum ----- */
 
 // Register type enumeration.
@@ -555,6 +616,13 @@ enum class AttributeType
     Partitioning,
     PatchSize,
     PatchConstantFunc,
+
+    #ifdef XSC_ENABLE_LANGUAGE_EXT
+
+    /* --- Language extensions --- */
+    Layout,
+
+    #endif
 };
 
 // Returns true if the specified attribute is supported since shader model 3.

--- a/src/Compiler/AST/TypeDenoter.h
+++ b/src/Compiler/AST/TypeDenoter.h
@@ -238,11 +238,17 @@ struct BufferTypeDenoter : public TypeDenoter
     // Always returns a valid generic type denoter. By default BaseTypeDenoter(Float4).
     TypeDenoterPtr GetGenericTypeDenoter() const;
 
-    BufferType      bufferType          = BufferType::Undefined;
-    TypeDenoterPtr  genericTypeDenoter;                             // May be null
-    int             genericSize         = 1;                        // Either number of samples in [1, 128) (for multi-sampled textures), or patch size. By default 1.
+    BufferType          bufferType          = BufferType::Undefined;
+    TypeDenoterPtr      genericTypeDenoter;                             // May be null
+    int                 genericSize         = 1;                        // Either number of samples in [1, 128) (for multi-sampled textures), or patch size. By default 1.
 
-    BufferDecl*     bufferDeclRef       = nullptr;
+    BufferDecl*         bufferDeclRef       = nullptr;
+
+    #ifdef XSC_ENABLE_LANGUAGE_EXT
+
+    ImageLayoutFormat   layoutFormat        = ImageLayoutFormat::Undefined;
+
+    #endif
 };
 
 // Sampler type denoter.

--- a/src/Compiler/AST/Visitor/ReferenceAnalyzer.cpp
+++ b/src/Compiler/AST/Visitor/ReferenceAnalyzer.cpp
@@ -250,9 +250,28 @@ IMPLEMENT_VISIT_PROC(CallExpr)
         }
     }
 
-    /* Collect all used intrinsics (if they can not be inlined) */
-    if (ast->intrinsic != Intrinsic::Undefined && !ast->flags(CallExpr::canInlineIntrinsicWrapper))
-        program_->RegisterIntrinsicUsage(ast->intrinsic, ast->arguments);
+    if (ast->intrinsic != Intrinsic::Undefined)
+    {
+        /* Mark RW buffers used in read operations */
+        if ((ast->intrinsic >= Intrinsic::Image_AtomicAdd && ast->intrinsic <= Intrinsic::Image_AtomicExchange) || ast->intrinsic == Intrinsic::Image_Load)
+        {
+            if(ast->arguments.size() > 0)
+            {
+                if (auto bufferTypeDen = ast->arguments[0]->GetTypeDenoter()->GetSub()->As<BufferTypeDenoter>())
+                {
+                    if(IsRWTextureBufferType(bufferTypeDen->bufferType))
+                    {
+                        if (auto bufferDecl = bufferTypeDen->bufferDeclRef)
+                            bufferDecl->flags << BufferDecl::isUsedForImageRead;
+                    }
+                }
+            }
+        }
+
+        /* Collect all used intrinsics (if they can not be inlined) */
+        if (!ast->flags(CallExpr::canInlineIntrinsicWrapper))
+            program_->RegisterIntrinsicUsage(ast->intrinsic, ast->arguments);
+    }
 
     /* Mark all arguments, that are assigned to output parameters, as l-values */
     ast->ForEachOutputArgument(

--- a/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.cpp
@@ -67,7 +67,7 @@ void GLSLGenerator::GenerateCodePrimary(
     alwaysBracedScopes_ = outputDesc.formatting.alwaysBracedScopes;
 
 #ifdef XSC_ENABLE_LANGUAGE_EXT
-    layoutAttrExt_      = true; //TODO: add compiler option.
+    extensions_         = inputDesc.extensions;
 #endif
 
     for (const auto& s : outputDesc.vertexSemantics)
@@ -2847,7 +2847,7 @@ void GLSLGenerator::WriteBufferDeclTexture(BufferDecl* bufferDecl)
     {
         #ifdef XSC_ENABLE_LANGUAGE_EXT
 
-        if(layoutAttrExt_)
+        if((extensions_ & Extensions::LayoutAttribute) != 0)
             imageLayoutFormat = bufferDecl->declStmntRef->typeDenoter->layoutFormat;
 
         #endif

--- a/src/Compiler/Backend/GLSL/GLSLGenerator.h
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.h
@@ -75,9 +75,6 @@ class GLSLGenerator : public Generator
         // Returns the GLSL keyword for the specified sampler type or reports and error.
         const std::string* SamplerTypeToKeyword(const SamplerType samplerType, const AST* ast = nullptr);
 
-        // Returns the GLSL image format keyword for the specified data type or reports and error.
-        const std::string* DataTypeToImageFormatKeyword(const DataType dataType, const AST* ast = nullptr);
-
         // Returns true if the specified type denoter is compatible with the semantic (e.g. 'SV_VertexID' is incompatible with 'UInt').
         bool IsTypeCompatibleWithSemantic(const Semantic semantic, const TypeDenoter& typeDenoter);
 
@@ -173,7 +170,6 @@ class GLSLGenerator : public Generator
         void WriteLayoutGlobalIn(const std::initializer_list<LayoutEntryFunctor>& entryFunctors, const LayoutEntryFunctor& varFunctor = nullptr);
         void WriteLayoutGlobalOut(const std::initializer_list<LayoutEntryFunctor>& entryFunctors, const LayoutEntryFunctor& varFunctor = nullptr);
         void WriteLayoutBinding(const std::vector<RegisterPtr>& slotRegisters);
-        void WriteLayoutImageFormat(const TypeDenoterPtr& typeDenoter, const AST* ast = nullptr);
 
 
         /* ----- Input semantics ----- */
@@ -313,6 +309,12 @@ class GLSLGenerator : public Generator
         bool                                    separateSamplers_       = true;
 
         bool                                    isInsideInterfaceBlock_ = false;
+
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+
+        bool                                    layoutAttrExt_          = false;        // Enables the language extension of the "layout" attribute.
+
+#endif
 };
 
 

--- a/src/Compiler/Backend/GLSL/GLSLGenerator.h
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.h
@@ -311,9 +311,7 @@ class GLSLGenerator : public Generator
         bool                                    isInsideInterfaceBlock_ = false;
 
 #ifdef XSC_ENABLE_LANGUAGE_EXT
-
-        bool                                    layoutAttrExt_          = false;        // Enables the language extension of the "layout" attribute.
-
+        int                                    extensions_              = 0;
 #endif
 };
 

--- a/src/Compiler/Backend/GLSL/GLSLKeywords.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLKeywords.cpp
@@ -132,30 +132,33 @@ const std::string* DataTypeToGLSLKeyword(const DataType t)
     return MapTypeToKeyword(typeMap, t);
 }
 
-/* ----- DataType (image format) Mapping ----- */
+/* ----- DataType to ImageLayoutFormat Mapping ----- */
 
-static std::map<DataType, std::string> GenerateDataTypeImageFormatMap()
+static std::map<DataType, ImageLayoutFormat> GenerateDataTypeImageLayoutFormatMap()
 {
     using T = DataType;
+    using U = ImageLayoutFormat;
 
     return
     {
-        { T::Int,       "r32i"      },
-        { T::Int2,      "rg32i"     },
-        { T::Int4,      "rgba32i"   },
-        { T::UInt,      "r32ui"     },
-        { T::UInt2,     "rg32ui"    },
-        { T::UInt4,     "rgba32ui"  },
-        { T::Float,     "r32f"      },
-        { T::Float2,    "rg32f"     },
-        { T::Float4,    "rgba32f"   },
+        { T::Int,       U::I32X1    },
+        { T::Int2,      U::I32X2    },
+        { T::Int4,      U::I32X4    },
+        { T::UInt,      U::UI32X1   },
+        { T::UInt2,     U::UI32X2   },
+        { T::UInt4,     U::UI32X4   },
+        { T::Float,     U::F32X1    },
+        { T::Float2,    U::F32X2    },
+        { T::Float4,    U::F32X4    },
     };
 }
 
-const std::string* DataTypeToImageFormatGLSLKeyword(const DataType t)
+ImageLayoutFormat DataTypeToImageLayoutFormat(const DataType t)
 {
-    static const auto typeMap = GenerateDataTypeImageFormatMap();
-    return MapTypeToKeyword(typeMap, t);
+    static const auto typeMap = GenerateDataTypeImageLayoutFormatMap();
+
+    auto it = typeMap.find(t);
+    return (it != typeMap.end() ? it->second : ImageLayoutFormat::Undefined);
 }
 
 
@@ -401,6 +404,61 @@ const std::string* PrimitiveTypeToGLSLKeyword(const PrimitiveType t)
     return MapTypeToKeyword(typeMap, t);
 }
 
+/* ----- ImageLayoutFormat Mapping ----- */
+
+static std::map<ImageLayoutFormat, std::string> GenerateImageLayoutFormatMap()
+{
+    using T = ImageLayoutFormat;
+
+    return
+    {
+        { T::F32X4,         "rgba32f"           },
+        { T::F32X2,         "rg32f"             },
+        { T::F32X1,         "r32f"              },
+        { T::F16X4,         "rgba16f"           },
+        { T::F16X2,         "rg16f"             },
+        { T::F16X1,         "r16f"              },
+        { T::F11R11G10B,    "r11f_g11f_b10f"    },
+        { T::UN32X4,        "rgba16"            },
+        { T::UN16X2,        "rg16"              },
+        { T::UN16X1,        "r16"               },
+        { T::UN10R10G10B2A, "rgb10_a2"          },
+        { T::UN8X4,         "rgba8"             },
+        { T::UN8X2,         "rg8"               },
+        { T::UN8X1,         "r8"                },
+        { T::SN16X4,        "rgba16_snorm"      },
+        { T::SN16X2,        "rg16_snorm"        },
+        { T::SN16X1,        "r16_snorm"         },
+        { T::SN8X4,         "rgba8_snorm"       },
+        { T::SN8X2,         "rg8_snorm"         },
+        { T::SN8X1,         "r8_snorm"          },
+        { T::I32X4,         "rgba32i"           },
+        { T::I32X2,         "rg32i"             },
+        { T::I32X1,         "r32i"              },
+        { T::I16X4,         "rgba16i"           },
+        { T::I16X2,         "rg16i"             },
+        { T::I16X1,         "r16i"              },
+        { T::I8X4,          "rgba8i"            },
+        { T::I8X2,          "rg8i"              },
+        { T::I8X1,          "r8i"               },
+        { T::UI32X4,        "rgba32ui"          },
+        { T::UI32X2,        "rg32ui"            },
+        { T::UI32X1,        "r32ui"             },
+        { T::UI16X4,        "rgba16ui"          },
+        { T::UI16X2,        "rg16ui"            },
+        { T::UI16X1,        "r16ui"             },
+        { T::UI10R10G10B2A, "rgb10_a2ui"        },
+        { T::UI8X4,         "rgba8ui"           },
+        { T::UI8X2,         "rg8ui"             },
+        { T::UI8X1,         "r8ui"              },
+    };
+}
+
+const std::string* ImageLayoutFormatToGLSLKeyword(const ImageLayoutFormat t)
+{
+    static const auto typeMap = GenerateImageLayoutFormatMap();
+    return MapTypeToKeyword(typeMap, t);
+}
 
 /* ----- Semantic Mapping ----- */
 

--- a/src/Compiler/Backend/GLSL/GLSLKeywords.h
+++ b/src/Compiler/Backend/GLSL/GLSLKeywords.h
@@ -26,8 +26,8 @@ bool IsGLSLKeyword(const std::string& ident);
 // Returns the GLSL keyword for the specified data type or null on failure.
 const std::string* DataTypeToGLSLKeyword(const DataType t);
 
-// Returns the GLSL image format keyword for the specified data type or null on failure.
-const std::string* DataTypeToImageFormatGLSLKeyword(const DataType t);
+// Returns the GLSL image format enum value for the specified data type or ImageLayoutFormat::Undefined.
+ImageLayoutFormat DataTypeToImageLayoutFormat(const DataType t);
 
 // Returns the GLSL keyword for the specified storage class or null on failure.
 const std::string* StorageClassToGLSLKeyword(const StorageClass t);
@@ -46,6 +46,9 @@ const std::string* AttributeValueToGLSLKeyword(const AttributeValue t);
 
 // Returns the GLSL keyword for the specified geometry primtive type or null on failure.
 const std::string* PrimitiveTypeToGLSLKeyword(const PrimitiveType t);
+
+// Returns the GLSL keyword for the specified image layout format or null on failure.
+const std::string* ImageLayoutFormatToGLSLKeyword(const ImageLayoutFormat t);
 
 // Returns the GLSL keyword for the specified semantic.
 // Special cases if 'useVulkanGLSL' is true.

--- a/src/Compiler/Frontend/HLSL/HLSLAnalyzer.cpp
+++ b/src/Compiler/Frontend/HLSL/HLSLAnalyzer.cpp
@@ -55,6 +55,10 @@ void HLSLAnalyzer::DecorateASTPrimary(
     shaderModel_            = GetShaderModel(inputDesc.shaderVersion);
     preferWrappers_         = outputDesc.options.preferWrappers;
 
+    #ifdef XSC_ENABLE_LANGUAGE_EXT
+    layoutAttrExt_          = true; //TODO: add compiler option.
+    #endif
+
     /* Decorate program AST */
     program_ = &program;
 
@@ -296,6 +300,20 @@ IMPLEMENT_VISIT_PROC(BufferDeclStmnt)
 
     /* Analyze buffer declarations */
     Visit(ast->bufferDecls);
+
+    #ifdef XSC_ENABLE_LANGUAGE_EXT
+
+    /* Analyze "layout" attribute (if this language extension is enabled) */
+    if (layoutAttrExt_)
+    {
+        for (const auto& attrib : ast->attribs)
+        {
+            if (attrib->attributeType == AttributeType::Layout)
+                AnalyzeAttributeLayout(attrib.get(), *ast);
+        }
+    }
+
+    #endif
 }
 
 IMPLEMENT_VISIT_PROC(UniformBufferDecl)
@@ -2095,6 +2113,51 @@ bool HLSLAnalyzer::AnalyzeAttributeValuePrimary(
     }
     return false;
 }
+
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+
+void HLSLAnalyzer::AnalyzeAttributeLayout(Attribute* attrib, BufferDeclStmnt& bufferDeclStmnt)
+{
+    if (auto typeDen = bufferDeclStmnt.typeDenoter.get())
+    {
+        if (AnalyzeNumArgsAttribute(attrib, 1, true))
+        {
+            auto expr = attrib->arguments[0].get();
+            if (auto objectExpr = expr->As<ObjectExpr>())
+            {
+                auto layoutFormat = objectExpr->ident;
+                auto imageLayoutFormat = ExtHLSLKeywordToImageLayoutFormat(layoutFormat);
+                if (imageLayoutFormat != ImageLayoutFormat::Undefined)
+                {
+                    auto baseType = DataType::Undefined;
+                    if (typeDen->genericTypeDenoter)
+                    {
+                        if (auto baseTypeDen = typeDen->genericTypeDenoter->As<BaseTypeDenoter>())
+                            baseType = BaseDataType(baseTypeDen->dataType);
+                    }
+                    
+                    /* Ensure format is used on a valid buffer type */
+                    if(baseType != DataType::Undefined)
+                    {
+                        auto formatBaseType = GetImageLayoutFormatBaseType(imageLayoutFormat);
+                        if(baseType != formatBaseType)
+                            Error(R_InvalidImageFormatForType(layoutFormat, DataTypeToString(baseType)));
+                        else
+                            typeDen->layoutFormat = imageLayoutFormat;
+                    }
+                    else
+                        typeDen->layoutFormat = imageLayoutFormat;
+                }
+                else
+                    Error(R_InvalidIdentArgInAttribute(layoutFormat, "layout"));
+            }
+            else
+                Error(R_ExpectedIdentArgInAttribute("layout"), expr);
+        }
+    }
+}
+
+#endif
 
 /* ----- Semantic ----- */
 

--- a/src/Compiler/Frontend/HLSL/HLSLAnalyzer.cpp
+++ b/src/Compiler/Frontend/HLSL/HLSLAnalyzer.cpp
@@ -56,7 +56,7 @@ void HLSLAnalyzer::DecorateASTPrimary(
     preferWrappers_         = outputDesc.options.preferWrappers;
 
     #ifdef XSC_ENABLE_LANGUAGE_EXT
-    layoutAttrExt_          = true; //TODO: add compiler option.
+    extensions_             = inputDesc.extensions;
     #endif
 
     /* Decorate program AST */
@@ -304,12 +304,14 @@ IMPLEMENT_VISIT_PROC(BufferDeclStmnt)
     #ifdef XSC_ENABLE_LANGUAGE_EXT
 
     /* Analyze "layout" attribute (if this language extension is enabled) */
-    if (layoutAttrExt_)
+    for (const auto& attrib : ast->attribs)
     {
-        for (const auto& attrib : ast->attribs)
+        if (attrib->attributeType == AttributeType::Layout)
         {
-            if (attrib->attributeType == AttributeType::Layout)
+            if ((extensions_ & Extensions::LayoutAttribute) != 0)
                 AnalyzeAttributeLayout(attrib.get(), *ast);
+            else
+                Warning(R_AttributeRequiresExtension("layout", "attr-layout"));
         }
     }
 

--- a/src/Compiler/Frontend/HLSL/HLSLAnalyzer.h
+++ b/src/Compiler/Frontend/HLSL/HLSLAnalyzer.h
@@ -183,6 +183,12 @@ class HLSLAnalyzer : public Analyzer
             std::string& literalValue
         );
 
+        #ifdef XSC_ENABLE_LANGUAGE_EXT
+
+        void AnalyzeAttributeLayout(Attribute* attrib, BufferDeclStmnt& bufferDeclStmnt);
+
+        #endif
+
         /* ----- Semantic ----- */
 
         void AnalyzeSemantic(IndexedSemantic& semantic);
@@ -211,6 +217,12 @@ class HLSLAnalyzer : public Analyzer
         bool                preferWrappers_             = false;
 
         std::set<VarDecl*>  varDeclSM3Semantics_;
+
+        #ifdef XSC_ENABLE_LANGUAGE_EXT
+
+        bool                layoutAttrExt_              = false;                        // Enables the language extension of the "layout" attribute.
+
+        #endif
 
 };
 

--- a/src/Compiler/Frontend/HLSL/HLSLAnalyzer.h
+++ b/src/Compiler/Frontend/HLSL/HLSLAnalyzer.h
@@ -219,9 +219,7 @@ class HLSLAnalyzer : public Analyzer
         std::set<VarDecl*>  varDeclSM3Semantics_;
 
         #ifdef XSC_ENABLE_LANGUAGE_EXT
-
-        bool                layoutAttrExt_              = false;                        // Enables the language extension of the "layout" attribute.
-
+        int                 extensions_                 = 0;
         #endif
 
 };

--- a/src/Compiler/Frontend/HLSL/HLSLKeywords.cpp
+++ b/src/Compiler/Frontend/HLSL/HLSLKeywords.cpp
@@ -905,6 +905,10 @@ static std::map<std::string, AttributeType> GenerateAttributeTypeMap()
         { "partitioning",              T::Partitioning              },
         { "patchsize",                 T::PatchSize                 },
         { "patchconstantfunc",         T::PatchConstantFunc         },
+
+        #ifdef XSC_ENABLE_LANGUAGE_EXT
+        { "layout",                    T::Layout                    },
+        #endif
     };
 }
 
@@ -1066,6 +1070,73 @@ IndexedSemantic HLSLKeywordToSemantic(const std::string& ident, bool useD3D10Sem
     else
         return HLSLKeywordToSemanticD3D9(ToCiString(ident));
 }
+
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+
+/* ----- ImageLayoutFormat Mapping ----- */
+
+static std::map<std::string, ImageLayoutFormat> GenerateImageLayoutFormatMap()
+{
+    using T = ImageLayoutFormat;
+
+    return
+    {
+        { "rgba32f",        T::F32X4            },
+        { "rg32f",          T::F32X2            },
+        { "r32f",           T::F32X1            },
+        { "rgba16f",        T::F16X4            },
+        { "rg16f",          T::F16X2            },
+        { "r16f",           T::F16X1            },
+        { "r11f_g11f_b10f", T::F11R11G10B       },
+
+        { "rgba16",         T::UN32X4           },
+        { "rg16",           T::UN16X2           },
+        { "r16",            T::UN16X1           },
+        { "rgb10_a2",       T::UN10R10G10B2A    },
+        { "rgba8",          T::UN8X4            },
+        { "rg8",            T::UN8X2            },
+        { "r8",             T::UN8X1            },
+
+
+        { "rgba16_snorm",   T::SN16X4           },
+        { "rg16_snorm",     T::SN16X2           },
+        { "r16_snorm",      T::SN16X1           },
+        { "rgba8_snorm",    T::SN8X4            },
+        { "rg8_snorm",      T::SN8X2            },
+        { "r8_snorm",       T::SN8X1            },
+
+        { "rgba32i",        T::I32X4            },
+        { "rg32i",          T::I32X2            },
+        { "r32i",           T::I32X1            },
+        { "rgba16i",        T::I16X4            },
+        { "rg16i",          T::I16X2            },
+        { "r16i",           T::I16X1            },
+        { "rgba8i",         T::I8X4             },
+        { "rg8i",           T::I8X2             },
+        { "r8i",            T::I8X1             },
+
+
+        { "rgba32ui",       T::UI32X4           },
+        { "rg32ui",         T::UI32X2           },
+        { "r32ui",          T::UI32X1           },
+        { "rgba16ui",       T::UI16X4           },
+        { "rg16ui",         T::UI16X2           },
+        { "r16ui",          T::UI16X1           },
+        { "rgb10_a2ui",     T::UI10R10G10B2A    },
+        { "rgba8ui",        T::UI8X4            },
+        { "rg8ui",          T::UI8X2            },
+        { "r8ui",           T::UI8X1            },
+    };
+}
+
+ImageLayoutFormat ExtHLSLKeywordToImageLayoutFormat(const std::string& keyword)
+{
+    static const auto typeMap = GenerateImageLayoutFormatMap();
+    auto it = typeMap.find(keyword);
+    return (it != typeMap.end() ? it->second : ImageLayoutFormat::Undefined);
+}
+
+#endif
 
 
 } // /namespace Xsc

--- a/src/Compiler/Frontend/HLSL/HLSLKeywords.h
+++ b/src/Compiler/Frontend/HLSL/HLSLKeywords.h
@@ -63,6 +63,13 @@ AttributeValue HLSLKeywordToAttributeValue(const std::string& keyword);
 // Returns the semantic for the specified identifier or Semantic::UserDefined if the identifier is not reserved.
 IndexedSemantic HLSLKeywordToSemantic(const std::string& ident, bool useD3D10Semantics = true);
 
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+
+// Maps a keyword from "layout" attribute extension into an image layout format or returns ImageLayoutFormat::Undefined.
+ImageLayoutFormat ExtHLSLKeywordToImageLayoutFormat(const std::string& keyword);
+
+#endif
+
 
 } // /namespace Xsc
 

--- a/src/Compiler/Report/ReportIdentsEN.h
+++ b/src/Compiler/Report/ReportIdentsEN.h
@@ -479,7 +479,8 @@ DECL_REPORT( OnlyPreProcessingForNonHLSL,       "only pre-processing supported f
 #ifdef XSC_ENABLE_LANGUAGE_EXT
 
 /* ----- Extensions ----- */
-DECL_REPORT( InvalidImageFormatForType,        "invalid image format '{0}' used for buffer of type '{1}'"                                                      );
+DECL_REPORT( InvalidImageFormatForType,         "invalid image format '{0}' used for buffer of type '{1}'"                                                      );
+DECL_REPORT( AttributeRequiresExtension,        "attribute[ '{0}'] requires extension '{1}'"                                                                    );
 
 #endif
 

--- a/src/Compiler/Report/ReportIdentsEN.h
+++ b/src/Compiler/Report/ReportIdentsEN.h
@@ -445,6 +445,8 @@ DECL_REPORT( DuplicateUseOfOutputSemantic,      "duplicate use of output semanti
 DECL_REPORT( UniformCantBeOutput,               "uniforms can not be defined as output"                                                                         );
 DECL_REPORT( TooManyArgsForAttribute,           "too many arguments for attribute[ '{0}'][ (expected {1}, but got {2})]"                                        );
 DECL_REPORT( TooFewArgsForAttribute,            "too few arguments for attribute[ '{0}'][ (expected {1}, but got {2})]"                                         );
+DECL_REPORT( ExpectedIdentArgInAttribute,       "expected identifier for argument in ['{0}' ]attribute"                                                         );
+DECL_REPORT( InvalidIdentArgInAttribute,        "invalid identifier '{0}' used for argument in ['{1}' ]attribute"                                               );
 DECL_REPORT( ExpectedDomainTypeParamToBe,       "expected domain type parameter to be \"tri\", \"quad\", or \"isoline\""                                        );
 DECL_REPORT( ExpectedOutputTopologyParamToBe,   "expected output topology parameter to be \"point\", \"line\", \"triangle_cw\", or \"triangle_ccw\""            );
 DECL_REPORT( ExpectedPartitioningModeParamToBe, "expected partitioning mode parameter to be \"integer\", \"pow2\", \"fractional_even\", or \"fractional_odd\""  );
@@ -474,6 +476,12 @@ DECL_REPORT( AnalyzingSourceFailed,             "analyzing input code failed"   
 DECL_REPORT( GeneratingOutputCodeFailed,        "generating output code failed"                                                                                 );
 DECL_REPORT( OnlyPreProcessingForNonHLSL,       "only pre-processing supported for shaders other than HLSL or Cg"                                               );
 
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+
+/* ----- Extensions ----- */
+DECL_REPORT( InvalidImageFormatForType,        "invalid image format '{0}' used for buffer of type '{1}'"                                                      );
+
+#endif
 
 #endif
 

--- a/src/Debugger/DebuggerView.cpp
+++ b/src/Debugger/DebuggerView.cpp
@@ -166,6 +166,10 @@ void DebuggerView::CreateLayoutPropertyGridShaderInput(wxPropertyGrid& pg)
     pg.Append(new wxStringProperty("Entry Point", "entry", ""));
     pg.Append(new wxStringProperty("Secondary Entry Point", "secondaryEntry", ""));
     pg.Append(new wxBoolProperty("Enable Warnings", "warnings"));
+
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+    pg.Append(new wxBoolProperty("Allow Language Extensions", "langExtensions"));
+#endif
 }
 
 void DebuggerView::CreateLayoutPropertyGridShaderOutput(wxPropertyGrid& pg)
@@ -413,6 +417,11 @@ void DebuggerView::OnPropertyGridChange(wxPropertyGridEvent& event)
         shaderInput_.shaderTarget = static_cast<ShaderTarget>(static_cast<long>(ShaderTarget::VertexShader) + ValueInt());
     else if (name == "outputVersion")
         shaderOutput_.shaderVersion = GetOutputVersion(ValueInt());
+
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+    else if (name == "langExtensions")
+        shaderInput_.extensions = (ValueBool() ? Extensions::All : 0);
+#endif
 
     /* --- Common options --- */
     else if (name == "indent")

--- a/src/Shell/Command.cpp
+++ b/src/Shell/Command.cpp
@@ -1314,6 +1314,49 @@ void SeparateSamplersCommand::Run(CommandLine& cmdLine, ShellState& state)
 }
 
 
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+
+/*
+ * LanguageExtensionCommand class
+ */
+
+std::vector<Command::Identifier> LanguageExtensionCommand::Idents() const
+{
+    return { { "-E", true } };
+}
+
+HelpDescriptor LanguageExtensionCommand::Help() const
+{
+    return
+    {
+        "-E<TYPE> [" + CommandLine::GetBooleanOption() + "]",
+        "Enables/disables the specified language extension; default=" + CommandLine::GetBooleanFalse() + "; value types:",
+        (
+            "all           => enables all extensions\n"                                                         \
+            "attr-layout   => allows the use of 'layout' attribute in order to specify image layout formats"
+        )
+    };
+}
+
+void LanguageExtensionCommand::Run(CommandLine& cmdLine, ShellState& state)
+{
+    const auto flags = MapStringToType<unsigned int>(
+        cmdLine.Accept(),
+        {
+            { "all",           Extensions::All },
+            { "attr-layout",   Extensions::LayoutAttribute },
+        },
+        "invalid extension type"
+        );
+
+    if (cmdLine.AcceptBoolean(true))
+        state.inputDesc.extensions |= flags;
+    else
+        state.inputDesc.extensions &= (~flags);
+}
+
+
+#endif
 } // /namespace Util
 
 } // /namespace Xsc

--- a/src/Shell/Command.h
+++ b/src/Shell/Command.h
@@ -105,7 +105,13 @@ DECL_SHELL_COMMAND( IndentCommand                );
 DECL_SHELL_COMMAND( PrefixCommand                );
 DECL_SHELL_COMMAND( NameManglingCommand          );
 DECL_SHELL_COMMAND( SeparateShadersCommand       );
-DECL_SHELL_COMMAND( SeparateSamplersCommand       );
+DECL_SHELL_COMMAND( SeparateSamplersCommand      );
+
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+
+DECL_SHELL_COMMAND( LanguageExtensionCommand     );
+
+#endif
 
 #undef DECL_SHELL_COMMAND
 

--- a/src/Shell/CommandFactory.cpp
+++ b/src/Shell/CommandFactory.cpp
@@ -89,6 +89,10 @@ CommandFactory::CommandFactory()
         NameManglingCommand,
         SeparateShadersCommand,
         SeparateSamplersCommand
+
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+       ,LanguageExtensionCommand
+#endif
     >();
 }
 

--- a/src/Wrapper/C/XscC.cpp
+++ b/src/Wrapper/C/XscC.cpp
@@ -122,6 +122,10 @@ static void InitializeShaderInput(struct XscShaderInput* s)
     s->secondaryEntryPoint  = NULL;
     s->warnings             = 0;
 
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+    s->extensions           = 0;
+#endif
+
     InitializeIncludeHandler(&(s->includeHandler));
 }
 
@@ -351,6 +355,10 @@ XSC_EXPORT bool XscCompileShader(
     in.secondaryEntryPoint  = ReadStringC(inputDesc->secondaryEntryPoint);
     in.warnings             = inputDesc->warnings;
     in.includeHandler       = (&includeHandler);
+
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+    in.extensions           = inputDesc->extensions;
+#endif
 
     /* Copy output descriptor */
     Xsc::ShaderOutput out;

--- a/src/Wrapper/CSharp/XscCSharp.cpp
+++ b/src/Wrapper/CSharp/XscCSharp.cpp
@@ -179,6 +179,21 @@ public ref class XscCompiler
             All                     = (~0u),    // All warnings.
         };
 
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+
+        //! Language extensions.
+        [Flags]
+        enum class Extensions : System::UInt32
+        {
+            Disabled                = 0,        // No extensions.
+
+            LayoutAttribute         = (1 << 0), //!< Enables the 'layout' attribute.
+
+            All                     = (~0u)     //!< All extensions.
+        };
+
+#endif
+
         /**
         \brief Static sampler state descriptor structure (D3D11_SAMPLER_DESC).
         \remarks All members and enumerations have the same values like the one in the "D3D11_SAMPLER_DESC" structure respectively.
@@ -517,6 +532,10 @@ public ref class XscCompiler
                     SecondaryEntryPoint = nullptr;
                     WarningFlags        = Warnings::Disabled;
                     IncludeHandler      = nullptr;
+
+                    #ifdef XSC_ENABLE_LANGUAGE_EXT
+                    ExtensionFlags      = Extensions::Disabled;
+                    #endif
                 }
 
                 //! Specifies the filename of the input shader code. This is an optional attribute, and only a hint to the compiler.
@@ -554,6 +573,16 @@ public ref class XscCompiler
                 \remarks If this is null, the default include handler will be used, which will include files with the STL input file streams.
                 */
                 property SourceIncludeHandler^          IncludeHandler;
+
+#ifdef XSC_ENABLE_LANGUAGE_EXT
+
+                /**
+                \brief Enabled language extensions. This can be a bitwise OR combination of the "Extensions" enumeration entries. By default 0.
+                \see Extensions
+                */
+                property Extensions                    ExtensionFlags;
+
+#endif
 
         };
 
@@ -994,6 +1023,10 @@ bool XscCompiler::CompileShader(ShaderInput^ inputDesc, ShaderOutput^ outputDesc
     in.secondaryEntryPoint  = ToStdString(inputDesc->SecondaryEntryPoint);
     in.warnings             = static_cast<unsigned int>(inputDesc->WarningFlags);
     in.includeHandler       = (&includeHandler);
+
+    #ifdef XSC_ENABLE_LANGUAGE_EXT
+    in.extensions           = static_cast<unsigned int>(inputDesc->ExtensionFlags);
+    #endif
 
     /* Copy output descriptor */
     Xsc::ShaderOutput out;

--- a/test/ExtLayoutAttrTest1.hlsl
+++ b/test/ExtLayoutAttrTest1.hlsl
@@ -1,0 +1,17 @@
+// Layout attribute extension test
+// 02/05/2017
+
+[layout(rg8i)]
+RWTexture2D<int2> tex;
+
+[layout(rgba32f)]
+RWTexture2D<float4> tex2;
+
+RWTexture2D<float4> tex3;
+
+void main()
+{
+	int a = tex[0].x;
+	float b = tex2[0].x;
+    float c = tex3[0].x;
+}

--- a/test/presetting.txt
+++ b/test/presetting.txt
@@ -193,3 +193,6 @@
 
 [MatrixLayoutTest1: vert]
 -T vert -E main -o output/* MatrixLayoutTest1.hlsl
+
+[ExtLayoutAttrTest1: vert]
+-T vert -E main -o output/* ExtLayoutAttrTest1.hlsl


### PR DESCRIPTION
I've added support for the 'layout' attribute that allows the user to specify image layout format such as `rgba8` using a non-standard `[layout(rgba8)]` attribute, as we discussed yesterday. 

This functionality is only enabled when `XSC_ENABLE_LANGUAGE_EXT` is enabled through CMake **AND** when the necessary extension is enabled through input options/CLI/GUI.

I've added the `-E<TYPE>` CLI option which works similar to `-W<TYPE>`, and allows specific (or all) extensions to be enabled. Since I know you are working on an extension of your own I assume this is preferred than having separate options for each extension.

The core additions are:
 - `ImageLayoutFormat` enumeration containing all image layout formats and a mapping to GLSL keywords. This is available even when extensions are disabled, since it is part of standard GLSL, and you might want to use this functionality for the input-option based solution to the image layout format problem (as discussed yesterday).
 - New layout attribute and a mapping of its identifiers to `ImageLayoutFormat` in `HLSLAnalyzer`. Resulting image layout is stored on relevant `BufferTypeDenoter`s.
 - Change to `GLSLGenerator::WriteBufferDeclTexture` so that image layout stored on `BufferTypeDenoter` is used if available. If one is not available or extension is disabled the system will try to deduce one automatically from base buffer type (similar how it worked so far). Finally if format cannot be deduced the buffer will be marked as `writeonly`, since formats are only needed for reads.
 
I'll probably do a secondary PR in which I track which buffers are actually being written to. In that case we can always avoid writing out the layout format, and since most RW buffers are only used for writes, this should allow the user to avoid attributes in majority of situations.