### PR TITLE
Ensure matrix initializers are nested

### DIFF
--- a/src/Compiler/AST/ASTFactory.cpp
+++ b/src/Compiler/AST/ASTFactory.cpp
@@ -62,6 +62,15 @@ CallExprPtr MakeTextureSamplerBindingCallExpr(const ExprPtr& textureObjectExpr, 
     return ast;
 }
 
+InitializerExprPtr MakeInitializerExpr(const std::vector<ExprPtr>& exprs)
+{
+    auto ast = MakeAST<InitializerExpr>();
+    {
+        ast->exprs = exprs;
+    }
+    return ast;
+}
+
 CallExprPtr MakeTypeCtorCallExpr(const TypeDenoterPtr& typeDenoter, const std::vector<ExprPtr>& arguments)
 {
     auto ast = MakeAST<CallExpr>();

--- a/src/Compiler/AST/ASTFactory.h
+++ b/src/Compiler/AST/ASTFactory.h
@@ -31,6 +31,8 @@ CallExprPtr                     MakeIntrinsicCallExpr(
 
 CallExprPtr                     MakeTextureSamplerBindingCallExpr(const ExprPtr& textureObjectExpr, const ExprPtr& samplerObjectExpr);
 
+InitializerExprPtr              MakeInitializerExpr(const std::vector<ExprPtr>& exprs);
+
 // Makes a type constructor function call.
 CallExprPtr                     MakeTypeCtorCallExpr(const TypeDenoterPtr& typeDenoter, const std::vector<ExprPtr>& arguments);
 

--- a/src/Compiler/AST/Visitor/ExprConverter.h
+++ b/src/Compiler/AST/Visitor/ExprConverter.h
@@ -115,6 +115,9 @@ class ExprConverter : public Visitor
         // Converts the expression from an initializer list to a type constructor.
         void ConvertExprTargetTypeInitializer(ExprPtr& expr, InitializerExpr* initExpr, const TypeDenoter& targetTypeDen);
 
+        // Convert a the initializer into GLSL-ready form.
+        void ConvertExprFormatInitializer(ExprPtr& expr, InitializerExpr* initExpr, const TypeDenoter& targetTypeDen);
+
         /* ----- Visitor implementation ----- */
 
         DECL_VISIT_PROC( VarDecl          );


### PR DESCRIPTION
Hi!

Flattened matrix initializers aren't supported by GLSL. This code is invalid:

```
const mat3 XYZTosRGBMatrix = 
{ 
     3.2409699419f, -1.5373831776f, -0.4986107603f, 
    -0.9692436363f,  1.8759675015f,  0.0415550574f, 
     0.0556300797f, -0.2039769589f,  1.0569715142f 
};
```

It should instead be:
```
const mat3 XYZTosRGBMatrix = 
{ 
    { 3.2409699419f, -1.5373831776f, -0.4986107603f },
    {-0.9692436363f,  1.8759675015f,  0.0415550574f }, 
    { 0.0556300797f, -0.2039769589f,  1.0569715142f } 
};
```

This fix does just that. It's only relevant for matrices and GLSL version 4.2 and higher (earlier versions generate matrix constructors instead).

P.S. 
My solution relies on `DeriveTypeDenoter` not being called on the initializer after it was modified, since it performs initializer unrolling. It feels hackish relying on side-effects like this, but it seems there is some unfinished code in `DeriveTypeDenoter` and I didn't feel comfortable messing with that, without a lot more investigation.