### PR TITLE
Bugfix: Don't generate separate samplers for MS textures

### DIFF
--- a/src/Compiler/Backend/GLSL/GLSLKeywords.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLKeywords.cpp
@@ -304,7 +304,7 @@ const std::string* BufferTypeToGLSLKeyword(const BufferType t, bool useVulkanGLS
     if (useVulkanGLSL && !separateSamplers)
     {
         auto samplerType = TextureTypeToSamplerType(t);
-        if (samplerType != SamplerType::Undefined)
+        if (samplerType != SamplerType::Undefined || t == BufferType::Texture2DMS || t == BufferType::Texture2DMSArray)
             useVulkanGLSL = false;
     }
 


### PR DESCRIPTION
When I added the code to disable generation of separate samplers on VKSL, I didn't account for MS textures. This patch fixes the problem.