### PR TITLE
auto-binding now also generates vertex input location bindings

### DIFF
--- a/src/Compiler/Backend/GLSL/GLSLGenerator.h
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.h
@@ -85,6 +85,12 @@ class GLSLGenerator : public Generator
         // Error for intrinsics, that can not be mapped to GLSL keywords.
         void ErrorIntrinsic(const std::string& intrinsicName, const AST* ast = nullptr);
 
+        // Returns the number of binding locations required by the specified type, or -1 if type is invalid.
+        int GetNumBindingLocations(const TypeDenoterPtr& typeDenoter);
+
+        // Attempts to find an empty binding location for the specified type, or returns -1 if it cannot find one. 
+        int GetBindingLocation(const TypeDenoterPtr& typeDenoter);
+
         /* --- Visitor implementation --- */
 
         DECL_VISIT_PROC( Program           );
@@ -308,8 +314,10 @@ class GLSLGenerator : public Generator
         bool                                    alwaysBracedScopes_     = false;
         bool                                    separateShaders_        = false;
         bool                                    separateSamplers_       = true;
+        bool                                    autoBinding_            = false;
 
         bool                                    isInsideInterfaceBlock_ = false;
+        std::set<int>                           usedLocationsSet_;
 
         #ifdef XSC_ENABLE_LANGUAGE_EXT
 


### PR DESCRIPTION
When auto-binding is enabled it will now also auto-generate `layout(location = X)` attributes. It works in tandem with explicit bindings provided to `ShaderOutput::vertexSemantics`, and it will only auto-generate locations for those not explicitly specified in that map.