### PR TITLE
Fix invalid code generation when both parameter & return value output semantics are used

### DIFF
--- a/src/Compiler/Frontend/HLSL/HLSLAnalyzer.cpp
+++ b/src/Compiler/Frontend/HLSL/HLSLAnalyzer.cpp
@@ -1510,24 +1510,6 @@ void HLSLAnalyzer::AnalyzeEntryPointInputOutput(FunctionDecl* funcDecl)
         AnalyzeEntryPointSemantics(funcDecl, inSemantics, outSemantics);
     }
 
-    /* Override all output semantics if the function has a return type semantic */
-    if (funcDecl->semantic.IsValid() && !funcDecl->outputSemantics.Empty())
-    {
-        int semanticIndex = 0;
-
-        funcDecl->outputSemantics.ForEach(
-            [&](VarDecl* varDecl)
-            {
-                varDecl->semantic = IndexedSemantic(funcDecl->semantic, semanticIndex);
-                ++semanticIndex;
-            }
-        );
-
-        funcDecl->outputSemantics.UpdateDistribution();
-
-        funcDecl->semantic.Reset();
-    }
-
     /* Check if there are duplicate output semantics */
     std::map<IndexedSemantic, int> outputSemanticCounter;
 


### PR DESCRIPTION
When both output parameter and return value semantics are present in an entry point (for example in a fragment shader for outputting to multiple render targets) there is invalid code generated:
 - Semantic indices are changed (which is particularily important for the case of `SV_Target` since it determines the index of the written render target)
 - Return value semantic is removed
 
For example, this code:
```
float4 main(
    out float4 o : SV_Target1,
    out float4 a : SV_Target2
) : SV_Target0
{
    o = 1;
    a = 3;
    return 2;
}
```

Gets converted into this:
```
#version 130

out vec4 SV_Target0;
out vec4 SV_Target1;

void main()
{
    SV_Target0 = vec4(1);
    SV_Target1 = vec4(3);
}
```

These bugs are caused by a single block of code in `HLSLAnalyzer::AnalyzeEntryPointInputOutput` which specificaly checks of these conditions (return value + non-zero semantic parameters). It then resets all the parameter semantic indices and then removes the return value semantic. 

I am not sure what was the intent of that block of code, therefore I left the block there but tried to fix the problem for my situation. 