### PR TITLE
Automatically generate all in/out 'location' modifiers when auto-bind is enabled

### DIFF
--- a/src/Compiler/Backend/GLSL/GLSLGenerator.h
+++ b/src/Compiler/Backend/GLSL/GLSLGenerator.h
@@ -89,7 +89,7 @@ class GLSLGenerator : public Generator
         int GetNumBindingLocations(TypeDenoterPtr typeDenoter);
 
         // Attempts to find an empty binding location for the specified type, or returns -1 if it cannot find one. 
-        int GetBindingLocation(const TypeDenoterPtr& typeDenoter);
+        int GetBindingLocation(const TypeDenoterPtr& typeDenoter, bool input);
 
         /* --- Visitor implementation --- */
 
@@ -195,7 +195,7 @@ class GLSLGenerator : public Generator
         
         void WriteGlobalOutputSemantics(FunctionDecl* entryPoint);
         void WriteGlobalOutputSemanticsVarDecl(VarDecl* varDecl, bool useSemanticName = false);
-        void WriteGlobalOutputSemanticsSlot(TypeSpecifier* typeSpecifier, const IndexedSemantic& semantic, const std::string& ident, VarDecl* varDecl = nullptr);
+        void WriteGlobalOutputSemanticsSlot(TypeSpecifier* typeSpecifier, IndexedSemantic& semantic, const std::string& ident, VarDecl* varDecl = nullptr);
 
         void WriteOutputSemanticsAssignment(Expr* expr, bool writeAsListedExpr = false);
         void WriteOutputSemanticsAssignmentStructDeclParam(
@@ -316,7 +316,8 @@ class GLSLGenerator : public Generator
         bool                                    autoBinding_            = false;
 
         bool                                    isInsideInterfaceBlock_ = false;
-        std::set<int>                           usedLocationsSet_;
+        std::set<int>                           usedInLocationsSet_;
+        std::set<int>                           usedOutLocationsSet_;
 
         #ifdef XSC_ENABLE_LANGUAGE_EXT
 


### PR DESCRIPTION
When `auto-bind` option is enabled, `layout(location = X)` will be generated for all shader inputs/outputs (e.g. vertex shader outputs that are being passed to a fragment as inputs). The behavior for vertex inputs is kept the same (prefer explicit bindings, and auto-generate if they don't exist), and fragment outputs remain using semantic index for location (they aren't influenced by auto-binding).

Again this was needed for Vulkan. OpenGL appears to perform name-matching between in/out variables of different shader stages, so specifying `location` isn't required. 

Vulkan doesn't do that, and requires explicit locations in order to match inputs to outputs.

----
This method requires that the **order** and **types** of inputs/outputs between stages matches, otherwise different locations will be generated for the stages.

As a later improvement, we could allow the user to specify explicit bindings for ALL inputs, like it's done for vertex shader. The user could then reflect the auto-generated output `location`s, and provide them as inputs for the compilation of the next stage.

Optionally, an extension attribute `[location(X)]` could also be added.