### PR TITLE
Added parsing for 'unorm' and 'snorm' modifiers within buffer type denoter

### DIFF
--- a/src/Compiler/Frontend/HLSL/HLSLParser.cpp
+++ b/src/Compiler/Frontend/HLSL/HLSLParser.cpp
@@ -1868,6 +1868,10 @@ BufferTypeDenoterPtr HLSLParser::ParseBufferTypeDenoter()
         {
             AcceptIt();
 
+            /* Parse optional 'unorm' or 'snorm' modifiers */
+            if (IsModifier())
+                AcceptIt();
+
             /* Parse generic type denoter ('<' TYPE '>') */
             typeDenoter->genericTypeDenoter = ParseTypeDenoter(false);
 


### PR DESCRIPTION
Hey again! As the title says, it's a small two line modification in order to properly parse buffer types such as:

`RWTexture3D<unorm float4> gOutputTex;`

This is needed because if you don't add `unorm`/`snorm` modifier, but you are using a DXGI _UNORM or _SNORM format for the Unordered Access View, DirectX will complain about undefined behavior. 

There doesn't seem to be such a requirement for GLSL, so I just ignored the parsed modifier.
