### PR TITLE
Workaround GCC compiler bug

### DIFF
--- a/src/Compiler/Frontend/HLSL/HLSLParser.cpp
+++ b/src/Compiler/Frontend/HLSL/HLSLParser.cpp
@@ -190,7 +190,7 @@ void HLSLParser::ProcessDirectivePragma()
         {
             if (!Is(type))
                 RuntimeErr(R_UnexpectedTokenInPackMatrixPragma);
-            return Parser::AcceptIt();
+            return this->Parser::AcceptIt();
         };
 
         AcceptToken(Tokens::LBracket);


### PR DESCRIPTION
In pre GCC 6.0 when you call a protected member inside a lambda function the compiler throws an error.
Specifically, I got the bug compiling for Android from CMake using ANDROID_STL=c++_static and ANDROID_TOOLCHAIN=gcc.

This bug in StackOverflow: https://stackoverflow.com/questions/19850648/error-when-calling-base-member-function-from-within-a-lambda
GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58972