### PR TITLE
Fix tex2D* intrinsics.

### DIFF
--- a/src/Compiler/AST/ASTEnums.cpp
+++ b/src/Compiler/AST/ASTEnums.cpp
@@ -1142,7 +1142,7 @@ bool IsAttributeValueTrianglePartitioning(const AttributeValue t)
 
 bool IsGlobalIntrinsic(const Intrinsic t)
 {
-    return (t >= Intrinsic::Abort && t <= Intrinsic::Trunc);
+    return (t >= Intrinsic::Abort && t <= Intrinsic::TexCubeProj);
 }
 
 bool IsTextureIntrinsic(const Intrinsic t)


### PR DESCRIPTION
The Trunc intrinsic was moved in the enum, but this orphaned the Tex* intrinsics so they could not be called.