### PR TITLE
GL 3.3/ARB_shader_bit_encoding fixes.

### DIFF
--- a/src/Compiler/Backend/GLSL/GLSLExtensionAgent.cpp
+++ b/src/Compiler/Backend/GLSL/GLSLExtensionAgent.cpp
@@ -27,9 +27,9 @@ GLSLExtensionAgent::GLSLExtensionAgent()
     intrinsicExtMap_ = std::map<Intrinsic, const char*>
     {
         { Intrinsic::AsDouble,                  E_GL_ARB_gpu_shader_int64   },
-        { Intrinsic::AsFloat,                   E_GL_ARB_gpu_shader5        },
-        { Intrinsic::AsInt,                     E_GL_ARB_gpu_shader5        },
-        { Intrinsic::AsUInt_1,                  E_GL_ARB_gpu_shader5        },
+        { Intrinsic::AsFloat,                   E_GL_ARB_shader_bit_encoding},
+        { Intrinsic::AsInt,                     E_GL_ARB_shader_bit_encoding},
+        { Intrinsic::AsUInt_1,                  E_GL_ARB_shader_bit_encoding},
         { Intrinsic::CountBits,                 E_GL_ARB_gpu_shader5        },
         { Intrinsic::DDXCoarse,                 E_GL_ARB_derivative_control },
         { Intrinsic::DDXFine,                   E_GL_ARB_derivative_control },

--- a/src/Compiler/Frontend/GLSL/GLSLExtensions.cpp
+++ b/src/Compiler/Frontend/GLSL/GLSLExtensions.cpp
@@ -37,6 +37,7 @@ const std::map<std::string, int>& GetGLSLExtensionVersionMap()
         { E_GL_ARB_enhanced_layouts,                        430 },
         { E_GL_ARB_explicit_attrib_location,                330 },
         { E_GL_ARB_fragment_coord_conventions,              150 },
+        { E_GL_ARB_shader_bit_encoding,                     330 },
         { E_GL_ARB_gpu_shader5,                             400 },
         { E_GL_ARB_gpu_shader_fp64,                         400 },
         { E_GL_ARB_gpu_shader_int64,                        450 },

--- a/src/Compiler/Frontend/GLSL/GLSLExtensions.h
+++ b/src/Compiler/Frontend/GLSL/GLSLExtensions.h
@@ -48,6 +48,7 @@ DECL_EXTENSION( GL_ARB_derivative_control                       );
 DECL_EXTENSION( GL_ARB_enhanced_layouts                         );
 DECL_EXTENSION( GL_ARB_explicit_attrib_location                 );
 DECL_EXTENSION( GL_ARB_fragment_coord_conventions               );
+DECL_EXTENSION( GL_ARB_shader_bit_encoding                      );
 DECL_EXTENSION( GL_ARB_gpu_shader5                              );
 DECL_EXTENSION( GL_ARB_gpu_shader_fp64                          );
 DECL_EXTENSION( GL_ARB_gpu_shader_int64                         );


### PR DESCRIPTION
ARB_shader_bit_encoding incorporates the type punning functions (ex: floatBitsToUint()) from GL_ARB_gpu_shader5 as a core extension in GL 3.3.

Not exactly sure if I set up the tables correctly though.

Relevant link.
https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_bit_encoding.txt